### PR TITLE
Added test steps for all threads as well as setup steps for checking …

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -37,6 +37,8 @@ cc_library(
     ],
     deps = [
         "@ocp_diag_core//ocpdiag/core/results:test_run",
+        "@ocp_diag_core//ocpdiag/core/results:test_step",
+        "@ocp_diag_core//ocpdiag/core/results/data_model:dut_info",
         "@ocp_diag_core//ocpdiag/core/results/data_model:input_model",
         "@ocp_diag_core//ocpdiag/core/results/data_model:input_model_helpers",
     ],

--- a/src/sat.h
+++ b/src/sat.h
@@ -18,6 +18,7 @@
 
 #include "finelock_queue.h"
 #include "ocpdiag/core/results/test_run.h"
+#include "ocpdiag/core/results/test_step.h"
 #include "os.h"
 #include "queue.h"
 #include "sattypes.h"
@@ -137,20 +138,20 @@ class Sat {
   string cmdline_json_;
 
   // Memory and test configuration.
-  int runtime_seconds_;               // Seconds to run.
-  int page_length_;                   // Length of each memory block.
-  int64 pages_;                       // Number of memory blocks.
-  int64 size_;                        // Size of memory tested, in bytes.
-  int64 size_mb_;                     // Size of memory tested, in MB.
-  int64 reserve_mb_;                  // Reserve at least this amount of memory
-                                      // for the system, in MB.
-  int64 min_hugepages_mbytes_;        // Minimum hugepages size.
-  int64 freepages_;                   // How many invalid pages we need.
-  int disk_pages_;                    // Number of pages per temp file.
-  uint64 paddr_base_;                 // Physical address base.
-  uint64 channel_hash_;               // Mask of address bits XORed for channel.
-  int channel_width_;                 // Channel width in bits.
-  vector<vector<string> > channels_;  // Memory module names per channel.
+  int runtime_seconds_;              // Seconds to run.
+  int page_length_;                  // Length of each memory block.
+  int64 pages_;                      // Number of memory blocks.
+  int64 size_;                       // Size of memory tested, in bytes.
+  int64 size_mb_;                    // Size of memory tested, in MB.
+  int64 reserve_mb_;                 // Reserve at least this amount of memory
+                                     // for the system, in MB.
+  int64 min_hugepages_mbytes_;       // Minimum hugepages size.
+  int64 freepages_;                  // How many invalid pages we need.
+  int disk_pages_;                   // Number of pages per temp file.
+  uint64 paddr_base_;                // Physical address base.
+  uint64 channel_hash_;              // Mask of address bits XORed for channel.
+  int channel_width_;                // Channel width in bits.
+  vector<vector<string>> channels_;  // Memory module names per channel.
 
   // Control flags.
   volatile sig_atomic_t user_break_;  // User has signalled early exit.  Used as
@@ -315,6 +316,7 @@ class Sat {
   Sat::PageQueueType pe_q_implementation_;  // Queue implementation switch
 
   std::unique_ptr<ocpdiag::results::TestRun> test_run_ = nullptr;
+  vector<std::unique_ptr<ocpdiag::results::TestStep>> thread_test_steps_;
 
   DISALLOW_COPY_AND_ASSIGN(Sat);
 };

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -270,10 +270,12 @@ NetworkListenThread::NetworkListenThread() {}
 void WorkerThread::InitThread(int thread_num_init, class Sat *sat_init,
                               class OsLayer *os_init,
                               class PatternList *patternlist_init,
-                              WorkerStatus *worker_status) {
+                              WorkerStatus *worker_status,
+                              ocpdiag::results::TestStep *test_step) {
   sat_assert(worker_status);
   worker_status->AddWorkers(1);
 
+  test_step_ = test_step;
   thread_num_ = thread_num_init;
   sat_ = sat_init;
   os_ = os_init;
@@ -2189,7 +2191,7 @@ bool NetworkListenThread::SpawnSlave(int newsock, int threadid) {
   ChildWorker *child_worker = new ChildWorker;
   child_worker->thread.SetSock(newsock);
   child_worker->thread.InitThread(threadid, sat_, os_, patternlist_,
-                                  &child_worker->status);
+                                  &child_worker->status, test_step_);
   child_worker->status.Initialize();
   child_worker->thread.SpawnThread();
   child_workers_.push_back(child_worker);

--- a/src/worker.h
+++ b/src/worker.h
@@ -29,6 +29,7 @@
 // This file must work with autoconf on its public version,
 // so these includes are correct.
 #include "disk_blocks.h"
+#include "ocpdiag/core/results/test_step.h"
 #include "queue.h"
 #include "sattypes.h"
 
@@ -204,7 +205,8 @@ class WorkerThread {
   virtual void InitThread(int thread_num_init, class Sat *sat_init,
                           class OsLayer *os_init,
                           class PatternList *patternlist_init,
-                          WorkerStatus *worker_status);
+                          WorkerStatus *worker_status,
+                          ocpdiag::results::TestStep *test_step);
 
   // This function is DEPRECATED, it does nothing.
   void SetPriority(Priority priority) { priority_ = priority; }
@@ -364,6 +366,8 @@ class WorkerThread {
   class Sat *sat_;                  // Reference to parent stest object.
   class OsLayer *os_;               // Os abstraction: put hacks here.
   class PatternList *patternlist_;  // Reference to data patterns.
+
+  ocpdiag::results::TestStep *test_step_;  // The OCP diag test step.
 
   // Work around style guide ban on sizeof(int).
   static const uint64 iamint_ = 0;


### PR DESCRIPTION
…the environment, filling memory pages, and then checking that memory copy operations were executed properly.

Internal reference: b/273820182

Tested:
```
dthawkes@dthawkes:~/ocp-diag-sat$ bazel-docker
Starting local Bazel server and connecting to it...
INFO: Analyzed 2 targets (127 packages loaded, 4252 targets configured).
INFO: Found 2 targets...
INFO: From Compiling src/sat.cc:
src/sat.cc: In member function 'int Sat::CacheLineSize()':
src/sat.cc:1538:21: warning: 'linesize' may be used uninitialized in this function [-Wmaybe-uninitialized]
 1538 |   int max_linesize, linesize;
      |                     ^~~~~~~~
INFO: Elapsed time: 13.563s, Critical Path: 8.29s
INFO: 7 processes: 1 internal, 6 processwrapper-sandbox.
INFO: Build completed successfully, 7 total actions
dthawkes@dthawkes:~/ocp-diag-sat$ ./bazel-bin/src/sat_bin
{"schemaVersion":{"major":2,"minor":0},"sequenceNumber":0,"timestamp":"2023-03-21T23:27:06Z"}
{"testRunArtifact":{"testRunStart":{"name":"Stress App Test","version":"1.0.0","commandLine":"./bazel-bin/src/sat_bin","parameters":{},"dutInfo":{"dutInfoId":"holder","name":"place","metadata":{},"platformInfos":[],"hardwareInfos":[],"softwareInfos":[]},"metadata":{}}},"sequenceNumber":1,"timestamp":"2023-03-21T23:27:06Z"}
{"testStepArtifact":{"testStepStart":{"name":"Setup and Check Environment"},"testStepId":"0"},"sequenceNumber":2,"timestamp":"2023-03-21T23:27:06Z"}
2023/03/21-23:27:06(UTC) Log: 1 nodes, 64 cpus.
2023/03/21-23:27:06(UTC) Log: Defaulting to 64 copy threads
2023/03/21-23:27:06(UTC) Log: Total 515961 MB. Free 493187 MB. Hugepages 0 MB. Targeting 489971 MB (94%)
2023/03/21-23:27:06(UTC) Log: Prefer plain malloc memory allocation.
2023/03/21-23:27:06(UTC) Log: Using mmap() allocation at 0x7ea2d871e000.
2023/03/21-23:27:06(UTC) Stats: Starting SAT, 489971M, 20 seconds
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"0"},"sequenceNumber":3,"timestamp":"2023-03-21T23:27:06Z"}
{"testStepArtifact":{"testStepStart":{"name":"Fill Memory Pages"},"testStepId":"1"},"sequenceNumber":4,"timestamp":"2023-03-21T23:27:06Z"}
2023/03/21-23:27:27(UTC) Log: Region mask: 0x1
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"1"},"sequenceNumber":5,"timestamp":"2023-03-21T23:27:27Z"}
{"testStepArtifact":{"testStepStart":{"name":"Poll for System Error Messages"},"testStepId":"2"},"sequenceNumber":6,"timestamp":"2023-03-21T23:27:27Z"}
{"testStepArtifact":{"testStepStart":{"name":"Run Memory Copy Threads"},"testStepId":"3"},"sequenceNumber":7,"timestamp":"2023-03-21T23:27:27Z"}
2023/03/21-23:27:37(UTC) Log: Seconds remaining: 10
{"testStepArtifact":{"testStepStart":{"name":"Run Post-Test Memory Check Threads"},"testStepId":"4"},"sequenceNumber":8,"timestamp":"2023-03-21T23:27:47Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"4"},"sequenceNumber":9,"timestamp":"2023-03-21T23:27:51Z"}
2023/03/21-23:27:51(UTC) Stats: Found 0 hardware incidents
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"2"},"sequenceNumber":10,"timestamp":"2023-03-21T23:27:51Z"}
2023/03/21-23:27:51(UTC) Stats: Completed: 2528154.00M in 20.09s 125839.50MB/s, with 0 hardware incidents, 0 errors
2023/03/21-23:27:51(UTC) Stats: Memory Copy: 2528154.00M at 126014.09MB/s
2023/03/21-23:27:51(UTC) Stats: File Copy: 0.00M at 0.00MB/s
2023/03/21-23:27:51(UTC) Stats: Net Copy: 0.00M at 0.00MB/s
2023/03/21-23:27:51(UTC) Stats: Data Check: 0.00M at 0.00MB/s
2023/03/21-23:27:51(UTC) Stats: Invert Data: 0.00M at 0.00MB/s
2023/03/21-23:27:51(UTC) Stats: Disk: 0.00M at 0.00MB/s
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"3"},"sequenceNumber":11,"timestamp":"2023-03-21T23:27:51Z"}
2023/03/21-23:27:51(UTC)
2023/03/21-23:27:51(UTC) Status: PASS - please verify no corrected errors
2023/03/21-23:27:51(UTC)
{"testRunArtifact":{"testRunEnd":{"status":"COMPLETE","result":"PASS"}},"sequenceNumber":12,"timestamp":"2023-03-21T23:27:56Z"}
```