### PR TITLE
Changed all logs to ocpdiag measurements, errors, logs, or diagnoses as appropriate for the SAT memory page initialization step.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "ocp_diag_core",
-    sha256 = "294b9b47e6d8cd49cefe48bd67f48e11fd1139b362f84c64c46a2566c5d26e14",
-    strip_prefix = "ocp-diag-core-3c3ae8d0464fd45536179a1309ca957a4fcbd676/apis/c++",
-    urls = ["https://github.com/opencomputeproject/ocp-diag-core/archive/3c3ae8d0464fd45536179a1309ca957a4fcbd676.zip"],  # 2023-03-08
+    sha256 = "af3eb900688c2d11c97ef51a93003cd4725f4756ee7d5c4d5fe389f10cb11995",
+    strip_prefix = "ocp-diag-core-f47fa7b48bac87bb2848de69217163208a3f963f/apis/c++",
+    urls = ["https://github.com/opencomputeproject/ocp-diag-core/archive/f47fa7b48bac87bb2848de69217163208a3f963f.zip"],  # 2023-03-22
 )
 
 load("@ocp_diag_core//ocpdiag:build_deps.bzl", "load_deps")

--- a/src/BUILD
+++ b/src/BUILD
@@ -36,6 +36,7 @@ cc_library(
         "worker.h",
     ],
     deps = [
+        "@com_google_absl//absl/strings:str_format",
         "@ocp_diag_core//ocpdiag/core/results:test_run",
         "@ocp_diag_core//ocpdiag/core/results:test_step",
         "@ocp_diag_core//ocpdiag/core/results/data_model:dut_info",

--- a/src/pattern.cc
+++ b/src/pattern.cc
@@ -351,6 +351,5 @@ Pattern *PatternList::GetRandomPattern() {
     return &patterns_[i];
   }
 
-  logprintf(0, "Process Error: Out of bounds pattern access\n");
   return 0;
 }

--- a/src/sat.h
+++ b/src/sat.h
@@ -300,7 +300,7 @@ class Sat {
   // Physical page use reporting.
   void AddrMapInit();
   void AddrMapUpdate(struct page_entry *pe);
-  void AddrMapPrint();
+  void AddrMapPrint(ocpdiag::results::TestStep &fill_step);
 
   // additional memory data from google-specific tests.
   virtual void GoogleMemoryStats(float *memcopy_data, float *memcopy_bandwidth);


### PR DESCRIPTION
Tested:

Note that the command line flags are set to make the test run faster for convience and to exercise all of the artifacts that we're added (specifically, --do_page_map). We are only interested in testStepId 1.

```
dthawkes@dthawkes:~/ocp-diag-sat$ ./bazel-bin/src/sat_bin -m 1 --do_page_map -M 1000 -s 1
{"schemaVersion":{"major":2,"minor":0},"sequenceNumber":0,"timestamp":"2023-03-22T23:13:40Z"}
{"testRunArtifact":{"testRunStart":{"name":"Stress App Test","version":"1.0.0","commandLine":"./bazel-bin/src/sat_bin -m 1 --do_page_map -M 1000 -s 1","parameters":{"1000":"-s","m":"1","do_page_map":"-M","1":""},"dutInfo":{"dutInfoId":"holder","name":"place","metadata":{},"platformInfos":[],"hardwareInfos":[],"softwareInfos":[]},"metadata":{}}},"sequenceNumber":1,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"testStepStart":{"name":"Setup and Check Environment"},"testStepId":"0"},"sequenceNumber":2,"timestamp":"2023-03-22T23:13:40Z"}
2023/03/22-23:13:40(UTC) Log: 1 nodes, 64 cpus.
2023/03/22-23:13:40(UTC) Log: Prefer plain malloc memory allocation.
2023/03/22-23:13:40(UTC) Log: Using mmap() allocation at 0x7f54c6e1e000.
2023/03/22-23:13:40(UTC) Stats: Starting SAT, 1000M, 1 seconds
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"0"},"sequenceNumber":3,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"testStepStart":{"name":"Setup and Fill Memory Pages"},"testStepId":"1"},"sequenceNumber":4,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"measurement":{"name":"Total Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[],"metadata":{},"value":1000},"testStepId":"1"},"sequenceNumber":5,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"measurement":{"name":"Required Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[],"metadata":{},"value":1},"testStepId":"1"},"sequenceNumber":6,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"measurement":{"name":"Free Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[{"name":"","type":"GREATER_THAN_OR_EQUAL","value":1},{"name":"","type":"LESS_THAN_OR_EQUAL","value":500}],"metadata":{},"value":400},"testStepId":"1"},"sequenceNumber":7,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Allocating memory pages, Total Pages: 1000, Free Pages: 400"},"testStepId":"1"},"sequenceNumber":8,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill threads: 8 threads, 1000 pages"},"testStepId":"1"},"sequenceNumber":9,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 0 to fill 125 pages"},"testStepId":"1"},"sequenceNumber":10,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 1 to fill 125 pages"},"testStepId":"1"},"sequenceNumber":11,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 2 to fill 125 pages"},"testStepId":"1"},"sequenceNumber":12,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 3 to fill 125 pages"},"testStepId":"1"},"sequenceNumber":13,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 4 to fill 125 pages"},"testStepId":"1"},"sequenceNumber":14,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 5 to fill 125 pages"},"testStepId":"1"},"sequenceNumber":15,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 6 to fill 125 pages"},"testStepId":"1"},"sequenceNumber":16,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 7 to fill 125 pages"},"testStepId":"1"},"sequenceNumber":17,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 0"},"testStepId":"1"},"sequenceNumber":18,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 1"},"testStepId":"1"},"sequenceNumber":19,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 3"},"testStepId":"1"},"sequenceNumber":20,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 7"},"testStepId":"1"},"sequenceNumber":21,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 2"},"testStepId":"1"},"sequenceNumber":22,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 5"},"testStepId":"1"},"sequenceNumber":23,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 6"},"testStepId":"1"},"sequenceNumber":24,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 4"},"testStepId":"1"},"sequenceNumber":25,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 1 completed. Status: 1. Filled 125 pages."},"testStepId":"1"},"sequenceNumber":26,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 3 completed. Status: 1. Filled 125 pages."},"testStepId":"1"},"sequenceNumber":27,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 2 completed. Status: 1. Filled 125 pages."},"testStepId":"1"},"sequenceNumber":28,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 7 completed. Status: 1. Filled 125 pages."},"testStepId":"1"},"sequenceNumber":29,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 5 completed. Status: 1. Filled 125 pages."},"testStepId":"1"},"sequenceNumber":30,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 4 completed. Status: 1. Filled 125 pages."},"testStepId":"1"},"sequenceNumber":31,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 6 completed. Status: 1. Filled 125 pages."},"testStepId":"1"},"sequenceNumber":32,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 0 completed. Status: 1. Filled 125 pages."},"testStepId":"1"},"sequenceNumber":33,"timestamp":"2023-03-22T23:13:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Done filling memory pages. Starting to allocate pages."},"testStepId":"1"},"sequenceNumber":34,"timestamp":"2023-03-22T23:13:40Z"}
2023/03/22-23:13:40(UTC) Log: Total 515961 MB. Free 499552 MB. Hugepages 0 MB. Targeting 489971 MB (94%)
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Done allocating pages."},"testStepId":"1"},"sequenceNumber":35,"timestamp":"2023-03-22T23:13:42Z"}
{"testStepArtifact":{"log":{"severity":"INFO","message":"Printing physical memory ranges that this test has accessed."},"testStepId":"1"},"sequenceNumber":36,"timestamp":"2023-03-22T23:13:42Z"}
{"testStepArtifact":{"log":{"severity":"INFO","message":"0000000000000000 - 0x00000000000fff"},"testStepId":"1"},"sequenceNumber":37,"timestamp":"2023-03-22T23:13:42Z"}
{"testStepArtifact":{"log":{"severity":"INFO","message":"Done print physical memory ranges."},"testStepId":"1"},"sequenceNumber":38,"timestamp":"2023-03-22T23:13:42Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Region 0 corresponds to 1000"},"testStepId":"1"},"sequenceNumber":39,"timestamp":"2023-03-22T23:13:42Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Region mask: 0x1"},"testStepId":"1"},"sequenceNumber":40,"timestamp":"2023-03-22T23:13:42Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"1"},"sequenceNumber":41,"timestamp":"2023-03-22T23:13:42Z"}
{"testStepArtifact":{"testStepStart":{"name":"Poll for System Error Messages"},"testStepId":"2"},"sequenceNumber":42,"timestamp":"2023-03-22T23:13:42Z"}
{"testStepArtifact":{"testStepStart":{"name":"Run Memory Copy Threads"},"testStepId":"3"},"sequenceNumber":43,"timestamp":"2023-03-22T23:13:42Z"}
{"testStepArtifact":{"testStepStart":{"name":"Run Post-Test Memory Check Threads"},"testStepId":"4"},"sequenceNumber":44,"timestamp":"2023-03-22T23:13:47Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"4"},"sequenceNumber":45,"timestamp":"2023-03-22T23:13:47Z"}
2023/03/22-23:13:47(UTC) Stats: Found 0 hardware incidents
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"2"},"sequenceNumber":46,"timestamp":"2023-03-22T23:13:47Z"}
2023/03/22-23:13:47(UTC) Stats: Completed: 103224.00M in 5.00s 20642.65MB/s, with 0 hardware incidents, 0 errors
2023/03/22-23:13:47(UTC) Stats: Memory Copy: 103224.00M at 20644.58MB/s
2023/03/22-23:13:47(UTC) Stats: File Copy: 0.00M at 0.00MB/s
2023/03/22-23:13:47(UTC) Stats: Net Copy: 0.00M at 0.00MB/s
2023/03/22-23:13:47(UTC) Stats: Data Check: 0.00M at 0.00MB/s
2023/03/22-23:13:47(UTC) Stats: Invert Data: 0.00M at 0.00MB/s
2023/03/22-23:13:47(UTC) Stats: Disk: 0.00M at 0.00MB/s
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"3"},"sequenceNumber":47,"timestamp":"2023-03-22T23:13:47Z"}
2023/03/22-23:13:47(UTC)
2023/03/22-23:13:47(UTC) Status: PASS - please verify no corrected errors
2023/03/22-23:13:47(UTC)
{"testRunArtifact":{"testRunEnd":{"status":"COMPLETE","result":"PASS"}},"sequenceNumber":48,"timestamp":"2023-03-22T23:13:47Z"}
```
