### PR TITLE
Transitioned setup step to ocpdiag

### DIFF
--- a/src/os.h
+++ b/src/os.h
@@ -21,7 +21,8 @@
 // so these includes are correct.
 #include "adler32memcpy.h"  // NOLINT
 #include "clock.h"          // NOLINT
-#include "sattypes.h"       // NOLINT
+#include "ocpdiag/core/results/test_step.h"
+#include "sattypes.h"  // NOLINT
 
 #if defined(STRESSAPPTEST_CPU_X86_64) || defined(STRESSAPPTEST_CPU_I686)
 #include <immintrin.h>
@@ -76,7 +77,7 @@ class OsLayer {
 
   // Initializes data strctures and open files.
   // Returns false on error.
-  virtual bool Initialize();
+  virtual bool Initialize(ocpdiag::results::TestStep &TestStep);
 
   // Virtual to physical. This implementation is optional for
   // subclasses to implement.
@@ -102,9 +103,6 @@ class OsLayer {
 
   // Returns the HD device that contains this file.
   virtual string FindFileDevice(string filename);
-
-  // Returns a list of paths coresponding to HD devices found on this machine.
-  virtual list<string> FindFileDevices();
 
   // Polls for errors. This implementation is optional.
   // This will poll once for errors and return zero iff no errors were found.
@@ -288,14 +286,16 @@ class OsLayer {
   }
 
   // Find the free memory on the machine.
-  virtual int64 FindFreeMemSize();
+  virtual int64 FindFreeMemSize(ocpdiag::results::TestStep &test_step);
 
   // Allocates test memory of length bytes.
   // Subclasses must implement this.
   // Call PepareTestMem to get a pointer.
-  virtual int64 AllocateAllMem();  // Returns length.
+  virtual int64 AllocateAllMem(
+      ocpdiag::results::TestStep &test_step);  // Returns length.
   // Returns success.
-  virtual bool AllocateTestMem(int64 length, uint64 paddr_base);
+  virtual bool AllocateTestMem(int64 length, uint64 paddr_base,
+                               ocpdiag::results::TestStep &test_step);
   virtual void FreeTestMem();
 
   // Prepares the memory for use. You must call this
@@ -303,14 +303,10 @@ class OsLayer {
   virtual void *PrepareTestMem(uint64 offset, uint64 length);
   virtual void ReleaseTestMem(void *addr, uint64 offset, uint64 length);
 
-  // Machine type detected. Can we implement all these functions correctly?
-  // Returns true if machine type is detected and implemented.
-  virtual bool IsSupported();
-
   // Returns 32 for 32-bit, 64 for 64-bit.
   virtual int AddressMode();
   // Update OsLayer state regarding cpu support for various features.
-  virtual void GetFeatures();
+  virtual void GetFeatures(ocpdiag::results::TestStep &setup_step);
 
   // Open, read, write pci cfg through /proc/bus/pci. fd is /proc/pci file.
   virtual int PciOpen(int bus, int device, int function);
@@ -405,7 +401,7 @@ class OsLayer {
   virtual int OpenMSR(uint32 core, uint32 address);
 
   // Look up how many hugepages there are.
-  virtual int64 FindHugePages();
+  virtual int64 FindHugePages(ocpdiag::results::TestStep &test_step);
 
   // Link to find last transaction at an error location.
   ErrCallback err_log_callback_;

--- a/src/os_factory.cc
+++ b/src/os_factory.cc
@@ -23,9 +23,6 @@ OsLayer *OsLayerFactory(const std::map<std::string, std::string> &options) {
   os = new OsLayer();
 
   // Check for memory allocation failure.
-  if (!os) {
-    logprintf(0, "Process Error: Can't allocate memory\n");
-    return 0;
-  }
+  if (!os) return 0;
   return os;
 }

--- a/src/sat.h
+++ b/src/sat.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/string_view.h"
 #include "finelock_queue.h"
 #include "ocpdiag/core/results/test_run.h"
 #include "ocpdiag/core/results/test_step.h"
@@ -23,6 +24,8 @@
 #include "queue.h"
 #include "sattypes.h"
 #include "worker.h"
+
+constexpr char kProcessError[] = "sat-process-error";
 
 // SAT stress test class.
 class Sat {
@@ -105,11 +108,11 @@ class Sat {
   // Opens log file for writing. Returns 0 on failure.
   bool InitializeLogfile();
   // Checks for supported environment. Returns 0 on failure.
-  bool CheckEnvironment();
+  bool CheckEnvironment(ocpdiag::results::TestStep &setup_step);
   // Allocates size_ bytes of test memory.
-  bool AllocateMemory();
+  bool AllocateMemory(ocpdiag::results::TestStep &setup_step);
   // Initializes datapattern reference structures.
-  bool InitializePatterns();
+  bool InitializePatterns(ocpdiag::results::TestStep &setup_step);
   // Initializes test memory with datapatterns.
   bool InitializePages();
 
@@ -162,7 +165,6 @@ class Sat {
   int warm_;                          // FPU warms CPU while copying.
   int address_mode_;                  // 32 or 64 bit binary.
   bool stop_on_error_;                // Exit immendiately on any error.
-  bool findfiles_;                    // Autodetect tempfile locations.
 
   bool error_injection_;        // Simulate errors, for unittests.
   bool crazy_error_injection_;  // Simulate lots of errors.
@@ -298,14 +300,12 @@ class Sat {
   void QueueStats();
 
   // Physical page use reporting.
-  void AddrMapInit();
+  void AddrMapInit(ocpdiag::results::TestStep &fill_step);
   void AddrMapUpdate(struct page_entry *pe);
   void AddrMapPrint(ocpdiag::results::TestStep &fill_step);
 
   // additional memory data from google-specific tests.
   virtual void GoogleMemoryStats(float *memcopy_data, float *memcopy_bandwidth);
-
-  virtual void GoogleOsOptions(std::map<std::string, std::string> *options);
 
   // Page queues, only one of (valid_+empty_) or (finelock_q_) will be used
   // at a time. A commandline switch controls which queue implementation will

--- a/src/worker.h
+++ b/src/worker.h
@@ -786,7 +786,7 @@ class CpuFreqThread : public WorkerThread {
 
   // Returns true if this test can run on the current machine. Otherwise,
   // returns false.
-  static bool CanRun();
+  static bool CanRun(ocpdiag::results::TestStep &test_step);
 
  private:
   static const int kIntervalPause = 10;   // The number of seconds to pause


### PR DESCRIPTION
Migrated all setup logs to the OCP diag library.

Internal reference: b/273823746

Tested:
```
dthawkes@dthawkes:~/ocp-diag-sat$ ./bazel-bin/src/sat_bin
{"schemaVersion":{"major":2,"minor":0},"sequenceNumber":0,"timestamp":"2023-03-29T20:05:56Z"}
{"testRunArtifact":{"testRunStart":{"name":"Stress App Test","version":"1.0.0","commandLine":"./bazel-bin/src/sat_bin","parameters":{},"dutInfo":{"dutInfoId":"holder","name":"place","metadata":{},"platformInfos":[],"hardwareInfos":[],"softwareInfos":[]},"metadata":{}}},"sequenceNumber":1,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"testStepStart":{"name":"Setup and Check Environment"},"testStepId":"0"},"sequenceNumber":2,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU has clflush and has sse2."},"testStepId":"0"},"sequenceNumber":3,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"measurement":{"name":"CPU Core Count","unit":"cores","hardwareInfoId":"","validators":[],"metadata":{},"value":64},"testStepId":"0"},"sequenceNumber":4,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"measurement":{"name":"Node Count","unit":"nodes","hardwareInfoId":"","validators":[],"metadata":{},"value":1},"testStepId":"0"},"sequenceNumber":5,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Defaulting to using 64 memory copy threads (same number as there are CPU cores)"},"testStepId":"0"},"sequenceNumber":6,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Total memory: 515961 MB, Free memory: 492283 MB, Hugepage memory: 0 MB. Targetting 489971 MB (94%) for testing."},"testStepId":"0"},"sequenceNumber":7,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"INFO","message":"Preferring plain malloc memory allocation."},"testStepId":"0"},"sequenceNumber":8,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"INFO","message":"Using mmap allocation at 0x7eaeccd1e000."},"testStepId":"0"},"sequenceNumber":9,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"measurement":{"name":"Memory to Test","unit":"MB","hardwareInfoId":"","validators":[],"metadata":{},"value":489971},"testStepId":"0"},"sequenceNumber":10,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"measurement":{"name":"Test Run Time","unit":"s","hardwareInfoId":"","validators":[],"metadata":{},"value":20},"testStepId":"0"},"sequenceNumber":11,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"0"},"sequenceNumber":12,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"testStepStart":{"name":"Setup and Fill Memory Pages"},"testStepId":"1"},"sequenceNumber":13,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"measurement":{"name":"Total Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[],"metadata":{},"value":489971},"testStepId":"1"},"sequenceNumber":14,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"measurement":{"name":"Required Thread Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[],"metadata":{},"value":64},"testStepId":"1"},"sequenceNumber":15,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"measurement":{"name":"Free Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[{"name":"","type":"GREATER_THAN_OR_EQUAL","value":64},{"name":"","type":"LESS_THAN_OR_EQUAL","value":244985}],"metadata":{},"value":195988},"testStepId":"1"},"sequenceNumber":16,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Allocating memory pages, Total Pages: 489971, Free Pages: 195988"},"testStepId":"1"},"sequenceNumber":17,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill threads: 8 threads, 489971 pages"},"testStepId":"1"},"sequenceNumber":18,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 0 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":19,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 1 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":20,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 2 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":21,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 3 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":22,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 4 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":23,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 5 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":24,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 6 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":25,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 7 to fill 61249 pages"},"testStepId":"1"},"sequenceNumber":26,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 0"},"testStepId":"1"},"sequenceNumber":27,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 2"},"testStepId":"1"},"sequenceNumber":28,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 3"},"testStepId":"1"},"sequenceNumber":29,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 4"},"testStepId":"1"},"sequenceNumber":30,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 7"},"testStepId":"1"},"sequenceNumber":31,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 1"},"testStepId":"1"},"sequenceNumber":32,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 6"},"testStepId":"1"},"sequenceNumber":33,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 5"},"testStepId":"1"},"sequenceNumber":34,"timestamp":"2023-03-29T20:05:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 2 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":35,"timestamp":"2023-03-29T20:06:11Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 4 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":36,"timestamp":"2023-03-29T20:06:11Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 7 completed. Status: 1. Filled 61249 pages."},"testStepId":"1"},"sequenceNumber":37,"timestamp":"2023-03-29T20:06:11Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 3 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":38,"timestamp":"2023-03-29T20:06:11Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 5 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":39,"timestamp":"2023-03-29T20:06:11Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 0 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":40,"timestamp":"2023-03-29T20:06:12Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 6 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":41,"timestamp":"2023-03-29T20:06:12Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 1 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":42,"timestamp":"2023-03-29T20:06:12Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Done filling memory pages. Starting to allocate pages."},"testStepId":"1"},"sequenceNumber":43,"timestamp":"2023-03-29T20:06:12Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Done allocating pages."},"testStepId":"1"},"sequenceNumber":44,"timestamp":"2023-03-29T20:06:17Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Region 0 corresponds to 489971"},"testStepId":"1"},"sequenceNumber":45,"timestamp":"2023-03-29T20:06:17Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Region mask: 0x1"},"testStepId":"1"},"sequenceNumber":46,"timestamp":"2023-03-29T20:06:17Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"1"},"sequenceNumber":47,"timestamp":"2023-03-29T20:06:17Z"}
{"testStepArtifact":{"testStepStart":{"name":"Poll for System Error Messages"},"testStepId":"2"},"sequenceNumber":48,"timestamp":"2023-03-29T20:06:17Z"}
{"testStepArtifact":{"testStepStart":{"name":"Run Memory Copy Threads"},"testStepId":"3"},"sequenceNumber":49,"timestamp":"2023-03-29T20:06:17Z"}
2023/03/29-20:06:28(UTC) Log: Seconds remaining: 10
{"testStepArtifact":{"testStepStart":{"name":"Run Post-Test Memory Check Threads"},"testStepId":"4"},"sequenceNumber":50,"timestamp":"2023-03-29T20:06:38Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"4"},"sequenceNumber":51,"timestamp":"2023-03-29T20:06:42Z"}
2023/03/29-20:06:42(UTC) Stats: Found 0 hardware incidents
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"2"},"sequenceNumber":52,"timestamp":"2023-03-29T20:06:42Z"}
2023/03/29-20:06:42(UTC) Stats: Completed: 2567254.00M in 20.41s 125753.75MB/s, with 0 hardware incidents, 0 errors
2023/03/29-20:06:42(UTC) Stats: Memory Copy: 2567254.00M at 126353.85MB/s
2023/03/29-20:06:42(UTC) Stats: File Copy: 0.00M at 0.00MB/s
2023/03/29-20:06:42(UTC) Stats: Net Copy: 0.00M at 0.00MB/s
2023/03/29-20:06:42(UTC) Stats: Data Check: 0.00M at 0.00MB/s
2023/03/29-20:06:42(UTC) Stats: Invert Data: 0.00M at 0.00MB/s
2023/03/29-20:06:42(UTC) Stats: Disk: 0.00M at 0.00MB/s
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"3"},"sequenceNumber":53,"timestamp":"2023-03-29T20:06:42Z"}
2023/03/29-20:06:42(UTC)
2023/03/29-20:06:42(UTC) Status: PASS - please verify no corrected errors
2023/03/29-20:06:42(UTC)
{"testRunArtifact":{"testRunEnd":{"status":"COMPLETE","result":"PASS"}},"sequenceNumber":54,"timestamp":"2023-03-29T20:06:45Z"}
```