### PR TITLE
Removed error poll functionality, as it is a no-op in open source.

### DIFF
--- a/src/os.cc
+++ b/src/os.cc
@@ -770,15 +770,6 @@ void OsLayer::ReleaseTestMem(void *addr, uint64 offset, uint64 length) {
   }
 }
 
-// No error polling on unknown systems.
-int OsLayer::ErrorPoll() { return 0; }
-
-// Generally, poll for errors once per second.
-void OsLayer::ErrorWait() {
-  sat_sleep(1);
-  return;
-}
-
 // Open a PCI bus-dev-func as a file and return its file descriptor.
 // Error is indicated by return value less than zero.
 int OsLayer::PciOpen(int bus, int device, int function) {

--- a/src/os.h
+++ b/src/os.h
@@ -103,13 +103,6 @@ class OsLayer {
   // Returns the HD device that contains this file.
   virtual string FindFileDevice(string filename);
 
-  // Polls for errors. This implementation is optional.
-  // This will poll once for errors and return zero iff no errors were found.
-  virtual int ErrorPoll();
-
-  // Delay an appropriate amount of time between polling.
-  virtual void ErrorWait();
-
   // Report errors. This implementation is mandatory.
   // This will output a machine readable line regarding the error.
   virtual bool ErrorReport(const char *part, const char *symptom, int count);

--- a/src/sat.h
+++ b/src/sat.h
@@ -228,7 +228,6 @@ class Sat {
   int disk_threads_;        // Threads of disk test.
   int random_threads_;      // Number of random disk threads.
   int total_threads_;       // Total threads used.
-  bool error_poll_;         // Poll for system errors.
 
   // Resources.
   cc_cacheline_data *cc_cacheline_data_;  // The cache line sized datastructure
@@ -263,9 +262,8 @@ class Sat {
     kDiskType = 6,
     kRandomDiskType = 7,
     kCPUType = 8,
-    kErrorType = 9,
-    kCCType = 10,
-    kCPUFreqType = 11,
+    kCCType = 9,
+    kCPUFreqType = 10,
   };
 
   // Helper functions.

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -2370,22 +2370,6 @@ bool NetworkSlaveThread::Work() {
   return true;
 }
 
-// Thread work loop. Execute until marked finished.
-bool ErrorPollThread::Work() {
-  logprintf(9, "Log: Starting system error poll thread %d\n", thread_num_);
-
-  // This calls a generic error polling function in the Os abstraction layer.
-  do {
-    errorcount_ += os_->ErrorPoll();
-    os_->ErrorWait();
-  } while (IsReadyToRun());
-
-  logprintf(9, "Log: Finished system error poll thread %d: %d errors\n",
-            thread_num_, errorcount_);
-  status_ = true;
-  return true;
-}
-
 // Worker thread to heat up CPU.
 // This thread does not evaluate pass/fail or software error.
 bool CpuStressThread::Work() {

--- a/src/worker.h
+++ b/src/worker.h
@@ -577,17 +577,6 @@ class CheckThread : public WorkerThread {
   DISALLOW_COPY_AND_ASSIGN(CheckThread);
 };
 
-// Worker thread to poll for system error messages.
-// Thread will check for messages until "done" flag is set.
-class ErrorPollThread : public WorkerThread {
- public:
-  ErrorPollThread() {}
-  virtual bool Work();
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ErrorPollThread);
-};
-
 // Computation intensive worker thread to stress CPU.
 class CpuStressThread : public WorkerThread {
  public:


### PR DESCRIPTION
Internal reference: 274515842
Tested:
```
dthawkes@dthawkes:~/ocp-diag-sat$ bazel-bin/src/sat_bin -m 0
{"schemaVersion":{"major":2,"minor":0},"sequenceNumber":0,"timestamp":"2023-04-07T21:32:22Z"}
{"testRunArtifact":{"testRunStart":{"name":"Stress App Test","version":"1.0.0","commandLine":"bazel-bin/src/sat_bin -m 0","parameters":{"m":"0"},"dutInfo":{"dutInfoId":"holder","name":"place","metadata":{},"platformInfos":[],"hardwareInfos":[],"softwareInfos":[]},"metadata":{}}},"sequenceNumber":1,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"testStepStart":{"name":"Setup and Check Environment"},"testStepId":"0"},"sequenceNumber":2,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU has clflush and has sse2."},"testStepId":"0"},"sequenceNumber":3,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"measurement":{"name":"CPU Core Count","unit":"cores","hardwareInfoId":"","validators":[],"metadata":{},"value":64},"testStepId":"0"},"sequenceNumber":4,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"measurement":{"name":"Node Count","unit":"nodes","hardwareInfoId":"","validators":[],"metadata":{},"value":1},"testStepId":"0"},"sequenceNumber":5,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Total memory: 515961 MB, Free memory: 491176 MB, Hugepage memory: 0 MB. Targetting 489971 MB (94%) for testing."},"testStepId":"0"},"sequenceNumber":6,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"INFO","message":"Preferring plain malloc memory allocation."},"testStepId":"0"},"sequenceNumber":7,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"INFO","message":"Using mmap allocation at 0x7f577951e000."},"testStepId":"0"},"sequenceNumber":8,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"measurement":{"name":"Memory to Test","unit":"MB","hardwareInfoId":"","validators":[],"metadata":{},"value":489971},"testStepId":"0"},"sequenceNumber":9,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"measurement":{"name":"Test Run Time","unit":"s","hardwareInfoId":"","validators":[],"metadata":{},"value":20},"testStepId":"0"},"sequenceNumber":10,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"0"},"sequenceNumber":11,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"testStepStart":{"name":"Setup and Fill Memory Pages"},"testStepId":"1"},"sequenceNumber":12,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"measurement":{"name":"Total Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[],"metadata":{},"value":489971},"testStepId":"1"},"sequenceNumber":13,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"measurement":{"name":"Required Thread Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[],"metadata":{},"value":0},"testStepId":"1"},"sequenceNumber":14,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"measurement":{"name":"Free Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[{"name":"","type":"GREATER_THAN_OR_EQUAL","value":0},{"name":"","type":"LESS_THAN_OR_EQUAL","value":244985}],"metadata":{},"value":195988},"testStepId":"1"},"sequenceNumber":15,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Allocating memory pages, Total Pages: 489971, Free Pages: 195988"},"testStepId":"1"},"sequenceNumber":16,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill threads: 8 threads, 489971 pages"},"testStepId":"1"},"sequenceNumber":17,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 0 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":18,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 1 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":19,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 2 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":20,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 3 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":21,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 4 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":22,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 5 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":23,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 6 to fill 61246 pages"},"testStepId":"1"},"sequenceNumber":24,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 7 to fill 61249 pages"},"testStepId":"1"},"sequenceNumber":25,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 0"},"testStepId":"1"},"sequenceNumber":26,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 2"},"testStepId":"1"},"sequenceNumber":27,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 5"},"testStepId":"1"},"sequenceNumber":28,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 3"},"testStepId":"1"},"sequenceNumber":29,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 6"},"testStepId":"1"},"sequenceNumber":30,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 4"},"testStepId":"1"},"sequenceNumber":31,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 7"},"testStepId":"1"},"sequenceNumber":32,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill thread 1"},"testStepId":"1"},"sequenceNumber":33,"timestamp":"2023-04-07T21:32:22Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 6 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":34,"timestamp":"2023-04-07T21:32:37Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 0 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":35,"timestamp":"2023-04-07T21:32:37Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 1 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":36,"timestamp":"2023-04-07T21:32:39Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 7 completed. Status: 1. Filled 61249 pages."},"testStepId":"1"},"sequenceNumber":37,"timestamp":"2023-04-07T21:32:39Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 3 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":38,"timestamp":"2023-04-07T21:32:39Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 4 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":39,"timestamp":"2023-04-07T21:32:40Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 5 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":40,"timestamp":"2023-04-07T21:32:41Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory page fill thread 2 completed. Status: 1. Filled 61246 pages."},"testStepId":"1"},"sequenceNumber":41,"timestamp":"2023-04-07T21:32:41Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Done filling memory pages. Starting to allocate pages."},"testStepId":"1"},"sequenceNumber":42,"timestamp":"2023-04-07T21:32:41Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Done allocating pages."},"testStepId":"1"},"sequenceNumber":43,"timestamp":"2023-04-07T21:32:46Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Region 0 corresponds to 489971"},"testStepId":"1"},"sequenceNumber":44,"timestamp":"2023-04-07T21:32:46Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Region mask: 0x1"},"testStepId":"1"},"sequenceNumber":45,"timestamp":"2023-04-07T21:32:46Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"1"},"sequenceNumber":46,"timestamp":"2023-04-07T21:32:46Z"}
2023/04/07-21:32:56(UTC) Log: Seconds remaining: 10
{"testStepArtifact":{"testStepStart":{"name":"Run Post-Test Memory Check Threads"},"testStepId":"2"},"sequenceNumber":47,"timestamp":"2023-04-07T21:33:06Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"2"},"sequenceNumber":48,"timestamp":"2023-04-07T21:33:10Z"}
2023/04/07-21:33:10(UTC) Stats: Found 0 hardware incidents
2023/04/07-21:33:10(UTC) Stats: Completed: 0.00M in 0.00s -nanMB/s, with 0 hardware incidents, 0 errors
2023/04/07-21:33:10(UTC) Stats: Memory Copy: 0.00M at 0.00MB/s
2023/04/07-21:33:10(UTC) Stats: File Copy: 0.00M at 0.00MB/s
2023/04/07-21:33:10(UTC) Stats: Net Copy: 0.00M at 0.00MB/s
2023/04/07-21:33:10(UTC) Stats: Data Check: 0.00M at 0.00MB/s
2023/04/07-21:33:10(UTC) Stats: Invert Data: 0.00M at 0.00MB/s
2023/04/07-21:33:10(UTC) Stats: Disk: 0.00M at 0.00MB/s
2023/04/07-21:33:10(UTC)
2023/04/07-21:33:10(UTC) Status: PASS - please verify no corrected errors
2023/04/07-21:33:10(UTC)
{"testRunArtifact":{"testRunEnd":{"status":"COMPLETE","result":"PASS"}},"sequenceNumber":49,"timestamp":"2023-04-07T21:33:15Z"}
```