### PR TITLE
Transferred all file thread logs and file thread function dependencies to their equivalent ocp diag reprsentation

### DIFF
--- a/src/error_diag.cc
+++ b/src/error_diag.cc
@@ -172,7 +172,7 @@ int ErrorDiag::AddMiscompareError(string dimm_string, uint64 addr, int count) {
   error->severity_ = SAT_ERROR_FATAL;
   error->addr_ = addr;
   dimm_device->AddErrorInstance(error);
-  os_->ErrorReport(dimm_string.c_str(), "miscompare", count);
+  // os_->ErrorReport(dimm_string.c_str(), "miscompare", count);
   return 1;
 }
 
@@ -236,7 +236,7 @@ int ErrorDiag::AddHDDMiscompareError(string devicename, int block, int offset,
 
   // HDD error was not masked by bad DIMMs: report bad HDD.
   if (!mask_hdd_error) {
-    os_->ErrorReport(devicename.c_str(), "miscompare", 1);
+    // os_->ErrorReport(devicename.c_str(), "miscompare", 1);
     error->severity_ = SAT_ERROR_FATAL;
     return 1;
   }
@@ -292,7 +292,7 @@ int ErrorDiag::AddHDDSectorTagError(string devicename, int block, int offset,
 
   // HDD error was not masked by bad DIMMs: report bad HDD.
   if (!mask_hdd_error) {
-    os_->ErrorReport(devicename.c_str(), "sector", 1);
+    // os_->ErrorReport(devicename.c_str(), "sector", 1);
     error->severity_ = SAT_ERROR_FATAL;
     return 1;
   }

--- a/src/os.h
+++ b/src/os.h
@@ -104,18 +104,14 @@ class OsLayer {
   // Returns the HD device that contains this file.
   virtual string FindFileDevice(string filename);
 
-  // Report errors. This implementation is mandatory.
-  // This will output a machine readable line regarding the error.
-  virtual bool ErrorReport(const char *part, const char *symptom, int count);
-
   // Flushes page cache. Used to circumvent the page cache when doing disk
   // I/O.  This will be a NOP until ActivateFlushPageCache() is called, which
   // is typically done when opening a file with O_DIRECT fails.
   // Returns false on error, true on success or NOP.
-  // Subclasses may implement this in machine specific ways..
-  virtual bool FlushPageCache(void);
+  // Subclasses may implement this in machine specific ways.
+  virtual bool FlushPageCache(ocpdiag::results::TestStep &test_step);
   // Enable FlushPageCache() to actually do the flush instead of being a NOP.
-  virtual void ActivateFlushPageCache(void);
+  virtual void ActivateFlushPageCache(ocpdiag::results::TestStep &test_step);
 
   // Flushes cacheline. Used to distinguish read or write errors.
   // Subclasses may implement this in machine specific ways..
@@ -293,8 +289,10 @@ class OsLayer {
 
   // Prepares the memory for use. You must call this
   // before using test memory, and after you are done.
-  virtual void *PrepareTestMem(uint64 offset, uint64 length);
-  virtual void ReleaseTestMem(void *addr, uint64 offset, uint64 length);
+  virtual void *PrepareTestMem(uint64 offset, uint64 length,
+                               ocpdiag::results::TestStep &test_step);
+  virtual void ReleaseTestMem(void *addr, uint64 offset, uint64 length,
+                              ocpdiag::results::TestStep &test_step);
 
   // Returns 32 for 32-bit, 64 for 64-bit.
   virtual int AddressMode();

--- a/src/sat.h
+++ b/src/sat.h
@@ -27,6 +27,11 @@
 
 constexpr char kProcessError[] = "sat-process-error";
 constexpr char kMemoryCopyFailVerdict[] = "sat-memory-copy-fail";
+constexpr char kFileWriteFailVerdict[] = "sat-file-write-fail";
+constexpr char kFileReadFailVerdict[] = "sat-file-read-fail";
+constexpr char kHddSectorTagFailVerdict[] = "sat-hdd-sector-tag-fail";
+constexpr char kHddMiscompareFailVerdict[] = "sat-hdd-crc-miscompare-fail";
+constexpr char kGeneralMiscompareFailVerdict[] = "sat-general-crc-miscompare-fail";
 
 // SAT stress test class.
 class Sat {
@@ -67,13 +72,15 @@ class Sat {
   void Break() { user_break_ = true; }
 
   // Fetch and return empty and full pages into the empty and full pools.
-  bool GetValid(struct page_entry *pe);
-  bool PutValid(struct page_entry *pe);
-  bool GetEmpty(struct page_entry *pe);
-  bool PutEmpty(struct page_entry *pe);
+  bool GetValid(struct page_entry *pe, ocpdiag::results::TestStep &test_step);
+  bool PutValid(struct page_entry *pe, ocpdiag::results::TestStep &test_step);
+  bool GetEmpty(struct page_entry *pe, ocpdiag::results::TestStep &test_step);
+  bool PutEmpty(struct page_entry *pe, ocpdiag::results::TestStep &test_step);
 
-  bool GetValid(struct page_entry *pe, int32 tag);
-  bool GetEmpty(struct page_entry *pe, int32 tag);
+  bool GetValid(struct page_entry *pe, int32 tag,
+                ocpdiag::results::TestStep &test_step);
+  bool GetEmpty(struct page_entry *pe, int32 tag,
+                ocpdiag::results::TestStep &test_step);
 
   // Accessor functions.
   int verbosity() const { return verbosity_; }

--- a/src/worker.h
+++ b/src/worker.h
@@ -343,9 +343,12 @@ class WorkerThread {
   // A worker thread can yield itself to give up CPU until it's scheduled again
   bool YieldSelf();
 
-  void AddLog(ocpdiag::results::LogSeverity severity, string message);
+  void AddLog(ocpdiag::results::LogSeverity severity, const string &message);
 
-  void AddProcessError(string message);
+  void AddProcessError(const string &message);
+
+  void AddDiagnosis(const string &verdict, ocpdiag::results::DiagnosisType type,
+                    const string &message);
 
  protected:
   // General state variables that all subclasses need.
@@ -388,12 +391,14 @@ class FileThread : public WorkerThread {
  public:
   FileThread();
   // Set filename to use for file IO.
-  virtual void SetFile(const char *filename_init);
+  virtual void SetFile(const string &filename_init);
   virtual bool Work();
 
   // Calculate worker thread specific bandwidth.
   virtual float GetDeviceCopiedData() { return GetCopiedData() * 2; }
   virtual float GetMemoryCopiedData();
+
+  string GetThreadTypeName() { return "File IO Thread"; }
 
  protected:
   // Record of where these pages were sourced from, and what
@@ -442,7 +447,6 @@ class FileThread : public WorkerThread {
   struct PageRec *page_recs_;  // Array of page records.
   int crc_page_;               // Page currently being CRC checked.
   string filename_;            // Name of file to access.
-  string devicename_;          // Name of device file is on.
 
   bool page_io_;      // Use page pool for IO.
   void *local_page_;  // malloc'd page fon non-pool IO.


### PR DESCRIPTION
Internal reference: 275900374

Tested:
dthawkes@dthawkes:~/ocp-diag-sat$ ./bazel-bin/src/sat_bin -f /tmp/tpm.1234 -m 1
{"schemaVersion":{"major":2,"minor":0},"sequenceNumber":0,"timestamp":"2023-04-26T01:29:56Z"}
{"testRunArtifact":{"testRunStart":{"name":"Stress App Test","version":"1.0.0","commandLine":"./bazel-bin/src/sat_bin -f /tmp/tpm.1234 -m 1","parameters":{"f":"/tmp/tpm.1234","m":"1"},"dutInfo":{"dutInfoId":"holder","name":"place","metadata":{},"platformInfos":[],"hardwareInfos":[],"softwareInfos":[]},"metadata":{}}},"sequenceNumber":1,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"testStepStart":{"name":"Setup and Check Environment"},"testStepId":"0"},"sequenceNumber":2,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU has clflush and has sse2."},"testStepId":"0"},"sequenceNumber":3,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"measurement":{"name":"CPU Core Count","unit":"cores","hardwareInfoId":"","validators":[],"metadata":{},"value":64},"testStepId":"0"},"sequenceNumber":4,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"measurement":{"name":"Node Count","unit":"nodes","hardwareInfoId":"","validators":[],"metadata":{},"value":1},"testStepId":"0"},"sequenceNumber":5,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Total memory: 515947 MB, Free memory: 496848 MB, Hugepage memory: 0 MB. Targetting 489958 MB (94%) for testing."},"testStepId":"0"},"sequenceNumber":6,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"INFO","message":"Preferring plain malloc memory allocation."},"testStepId":"0"},"sequenceNumber":7,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"INFO","message":"Using mmap allocation at 0x7efb9ea1e000."},"testStepId":"0"},"sequenceNumber":8,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"measurement":{"name":"Memory to Test","unit":"MB","hardwareInfoId":"","validators":[],"metadata":{},"value":489958},"testStepId":"0"},"sequenceNumber":9,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"measurement":{"name":"Test Run Time","unit":"s","hardwareInfoId":"","validators":[],"metadata":{},"value":20},"testStepId":"0"},"sequenceNumber":10,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"0"},"sequenceNumber":11,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"testStepStart":{"name":"Setup and Fill Memory Pages"},"testStepId":"1"},"sequenceNumber":12,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"measurement":{"name":"Total Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[],"metadata":{},"value":489958},"testStepId":"1"},"sequenceNumber":13,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"measurement":{"name":"Required Thread Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[],"metadata":{},"value":2},"testStepId":"1"},"sequenceNumber":14,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"measurement":{"name":"Free Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[{"name":"","type":"GREATER_THAN_OR_EQUAL","value":2},{"name":"","type":"LESS_THAN_OR_EQUAL","value":244979}],"metadata":{},"value":195982},"testStepId":"1"},"sequenceNumber":15,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Allocating memory pages, Total Pages: 489958, Free Pages: 195982"},"testStepId":"1"},"sequenceNumber":16,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill threads: 8 threads, 489958 pages"},"testStepId":"1"},"sequenceNumber":17,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 0 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":18,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 1 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":19,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 2 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":20,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 3 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":21,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 4 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":22,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 5 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":23,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 6 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":24,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 7 to fill 61250 pages"},"testStepId":"1"},"sequenceNumber":25,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #0: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":26,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #1: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":27,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #3: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":28,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #7: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":29,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #5: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":30,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #2: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":31,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #6: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":32,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #4: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":33,"timestamp":"2023-04-26T01:29:56Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #5: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":34,"timestamp":"2023-04-26T01:30:09Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #1: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":35,"timestamp":"2023-04-26T01:30:09Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #0: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":36,"timestamp":"2023-04-26T01:30:10Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #4: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":37,"timestamp":"2023-04-26T01:30:10Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #2: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":38,"timestamp":"2023-04-26T01:30:10Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #7: Completed. Status: Success. Filled 61250 pages."},"testStepId":"1"},"sequenceNumber":39,"timestamp":"2023-04-26T01:30:10Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #3: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":40,"timestamp":"2023-04-26T01:30:10Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #6: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":41,"timestamp":"2023-04-26T01:30:11Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Done filling memory pages. Starting to allocate pages."},"testStepId":"1"},"sequenceNumber":42,"timestamp":"2023-04-26T01:30:11Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Done allocating pages."},"testStepId":"1"},"sequenceNumber":43,"timestamp":"2023-04-26T01:30:14Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Region 0 corresponds to 489958"},"testStepId":"1"},"sequenceNumber":44,"timestamp":"2023-04-26T01:30:14Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Region mask: 0x1"},"testStepId":"1"},"sequenceNumber":45,"timestamp":"2023-04-26T01:30:14Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"1"},"sequenceNumber":46,"timestamp":"2023-04-26T01:30:14Z"}
{"testStepArtifact":{"testStepStart":{"name":"Run Memory Copy Threads"},"testStepId":"2"},"sequenceNumber":47,"timestamp":"2023-04-26T01:30:14Z"}
{"testStepArtifact":{"testStepStart":{"name":"Run File IO Threads"},"testStepId":"3"},"sequenceNumber":48,"timestamp":"2023-04-26T01:30:14Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"File IO Thread #1: Starting file thread using file: /tmp/tpm.1234"},"testStepId":"3"},"sequenceNumber":49,"timestamp":"2023-04-26T01:30:14Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Copy Thread #0: Starting memory copy thread. CPU: 1, Mem: ffffffff, Warming: No, Has Vector: Yes"},"testStepId":"2"},"sequenceNumber":50,"timestamp":"2023-04-26T01:30:14Z"}
2023/04/26-01:30:24(UTC) Log: Seconds remaining: 10
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Copy Thread #0: Status: Success, 192827 pages copied."},"testStepId":"2"},"sequenceNumber":51,"timestamp":"2023-04-26T01:30:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"File IO Thread #1: Completed 1: file thread status 0, 6632 pages copied"},"testStepId":"3"},"sequenceNumber":52,"timestamp":"2023-04-26T01:30:34Z"}
{"testStepArtifact":{"testStepStart":{"name":"Run Post-Test Memory Check Threads"},"testStepId":"4"},"sequenceNumber":53,"timestamp":"2023-04-26T01:30:34Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"4"},"sequenceNumber":54,"timestamp":"2023-04-26T01:30:37Z"}
2023/04/26-01:30:37(UTC) Stats: Found 0 hardware incidents
2023/04/26-01:30:37(UTC) Stats: Completed: 398918.00M in 20.02s 19922.85MB/s, with 0 hardware incidents, 0 errors
2023/04/26-01:30:37(UTC) Stats: Memory Copy: 385654.00M at 19281.79MB/s
2023/04/26-01:30:37(UTC) Stats: File Copy: 13264.00M at 662.43MB/s
2023/04/26-01:30:37(UTC) Stats: Net Copy: 0.00M at 0.00MB/s
2023/04/26-01:30:37(UTC) Stats: Data Check: 0.00M at 0.00MB/s
2023/04/26-01:30:37(UTC) Stats: Invert Data: 0.00M at 0.00MB/s
2023/04/26-01:30:37(UTC) Stats: Disk: 0.00M at 0.00MB/s
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"2"},"sequenceNumber":55,"timestamp":"2023-04-26T01:30:37Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"3"},"sequenceNumber":56,"timestamp":"2023-04-26T01:30:37Z"}
2023/04/26-01:30:37(UTC)
2023/04/26-01:30:37(UTC) Status: PASS - please verify no corrected errors
2023/04/26-01:30:37(UTC)
{"testRunArtifact":{"testRunEnd":{"status":"COMPLETE","result":"PASS"}},"sequenceNumber":57,"timestamp":"2023-04-26T01:30:39Z"}