### PR TITLE
Converted logs to the ocp format for the invert thread step

### DIFF
--- a/src/sat.cc
+++ b/src/sat.cc
@@ -1336,13 +1336,13 @@ void Sat::InitializeThreads() {
   if (check_threads_ > 0) thread_test_steps_.push_back(std::move(check_step));
 
   // Memory invert threads.
-  // TODO(b/274523085) Populate memory invert step
   std::unique_ptr<TestStep> invert_step;
   if (invert_threads_ > 0) {
     invert_step =
         std::make_unique<TestStep>("Run Memory Invert Threads", *test_run_);
+    invert_step->AddLog(Log{.severity = LogSeverity::kDebug,
+                            .message = "Starting memory invert threads"});
   }
-  logprintf(12, "Log: Starting invert threads\n");
   WorkerVector *invert_vector = new WorkerVector();
   for (int i = 0; i < invert_threads_; i++) {
     InvertThread *thread = new InvertThread();

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1515,15 +1515,13 @@ bool InvertThread::Work() {
   bool result = true;
   int64 loops = 0;
 
-  logprintf(9, "Log: Starting invert thread %d\n", thread_num_);
+  AddLog(LogSeverity::kDebug, "Starting memory invert thread");
 
   while (IsReadyToRun()) {
     // Pop the needed pages.
     result = result && sat_->GetValid(&src, *test_step_);
     if (!result) {
-      logprintf(0,
-                "Process Error: invert_thread failed to pop pages, "
-                "bailing\n");
+      AddProcessError("Failed to pop pages");
       break;
     }
 
@@ -1546,9 +1544,7 @@ bool InvertThread::Work() {
 
     result = result && sat_->PutValid(&src, *test_step_);
     if (!result) {
-      logprintf(0,
-                "Process Error: invert_thread failed to push pages, "
-                "bailing\n");
+      AddProcessError("Failed to push pages");
       break;
     }
     loops++;
@@ -1556,8 +1552,10 @@ bool InvertThread::Work() {
 
   pages_copied_ = loops * 2;
   status_ = result;
-  logprintf(9, "Log: Completed %d: Copy thread. Status %d, %d pages copied\n",
-            thread_num_, status_, pages_copied_);
+  AddLog(LogSeverity::kDebug,
+         absl::StrFormat(
+             "Invert thread completed with status %d and %d pages copied",
+             status_, pages_copied_));
   return result;
 }
 

--- a/src/worker.h
+++ b/src/worker.h
@@ -559,6 +559,8 @@ class InvertThread : public WorkerThread {
   // Calculate worker thread specific bandwidth.
   virtual float GetMemoryCopiedData() { return GetCopiedData() * 4; }
 
+  string GetThreadTypeName() { return "Memory Page Invert Thread"; }
+
  private:
   virtual int InvertPageUp(struct page_entry *srcpe);
   virtual int InvertPageDown(struct page_entry *srcpe);


### PR DESCRIPTION
Internal Reference: 274523085

Tested:
```
dthawkes@dthawkes:~/ocp-diag-sat$ ./bazel-bin/src/sat_bin -m 1 -i 1
{"schemaVersion":{"major":2,"minor":0},"sequenceNumber":0,"timestamp":"2023-05-01T15:42:53Z"}
{"testRunArtifact":{"testRunStart":{"name":"Stress App Test","version":"1.0.0","commandLine":"./bazel-bin/src/sat_bin -m 1 -i 1","parameters":{"m":"1","i":"1"},"dutInfo":{"dutInfoId":"holder","name":"place","metadata":{},"platformInfos":[],"hardwareInfos":[],"softwareInfos":[]},"metadata":{}}},"sequenceNumber":1,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"testStepStart":{"name":"Setup and Check Environment"},"testStepId":"0"},"sequenceNumber":2,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU has clflush and has sse2."},"testStepId":"0"},"sequenceNumber":3,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"measurement":{"name":"CPU Core Count","unit":"cores","hardwareInfoId":"","validators":[],"metadata":{},"value":64},"testStepId":"0"},"sequenceNumber":4,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"measurement":{"name":"Node Count","unit":"nodes","hardwareInfoId":"","validators":[],"metadata":{},"value":1},"testStepId":"0"},"sequenceNumber":5,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Total memory: 515947 MB, Free memory: 485026 MB, Hugepage memory: 0 MB. Targetting 489958 MB (94%) for testing."},"testStepId":"0"},"sequenceNumber":6,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"INFO","message":"Preferring plain malloc memory allocation."},"testStepId":"0"},"sequenceNumber":7,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"INFO","message":"Using mmap allocation at 0x7e94c921e000."},"testStepId":"0"},"sequenceNumber":8,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"measurement":{"name":"Memory to Test","unit":"MB","hardwareInfoId":"","validators":[],"metadata":{},"value":489958},"testStepId":"0"},"sequenceNumber":9,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"measurement":{"name":"Test Run Time","unit":"s","hardwareInfoId":"","validators":[],"metadata":{},"value":20},"testStepId":"0"},"sequenceNumber":10,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"0"},"sequenceNumber":11,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"testStepStart":{"name":"Setup and Fill Memory Pages"},"testStepId":"1"},"sequenceNumber":12,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"measurement":{"name":"Total Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[],"metadata":{},"value":489958},"testStepId":"1"},"sequenceNumber":13,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"measurement":{"name":"Required Thread Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[],"metadata":{},"value":2},"testStepId":"1"},"sequenceNumber":14,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"measurement":{"name":"Free Memory Page Count","unit":"pages","hardwareInfoId":"","validators":[{"name":"","type":"GREATER_THAN_OR_EQUAL","value":2},{"name":"","type":"LESS_THAN_OR_EQUAL","value":244979}],"metadata":{},"value":195982},"testStepId":"1"},"sequenceNumber":15,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Allocating memory pages, Total Pages: 489958, Free Pages: 195982"},"testStepId":"1"},"sequenceNumber":16,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill threads: 8 threads, 489958 pages"},"testStepId":"1"},"sequenceNumber":17,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 0 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":18,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 1 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":19,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 2 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":20,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 3 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":21,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 4 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":22,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 5 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":23,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 6 to fill 61244 pages"},"testStepId":"1"},"sequenceNumber":24,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory page fill Thread 7 to fill 61250 pages"},"testStepId":"1"},"sequenceNumber":25,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #0: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":26,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #4: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":27,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #1: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":28,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #5: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":29,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #2: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":30,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #7: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":31,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #6: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":32,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #3: Starting memory page fill thread"},"testStepId":"1"},"sequenceNumber":33,"timestamp":"2023-05-01T15:42:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #5: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":34,"timestamp":"2023-05-01T15:43:05Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #4: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":35,"timestamp":"2023-05-01T15:43:06Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #0: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":36,"timestamp":"2023-05-01T15:43:06Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #7: Completed. Status: Success. Filled 61250 pages."},"testStepId":"1"},"sequenceNumber":37,"timestamp":"2023-05-01T15:43:07Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #1: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":38,"timestamp":"2023-05-01T15:43:07Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #3: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":39,"timestamp":"2023-05-01T15:43:08Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #6: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":40,"timestamp":"2023-05-01T15:43:08Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Fill Thread #2: Completed. Status: Success. Filled 61244 pages."},"testStepId":"1"},"sequenceNumber":41,"timestamp":"2023-05-01T15:43:08Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Done filling memory pages. Starting to allocate pages."},"testStepId":"1"},"sequenceNumber":42,"timestamp":"2023-05-01T15:43:08Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Done allocating pages."},"testStepId":"1"},"sequenceNumber":43,"timestamp":"2023-05-01T15:43:11Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Region 0 corresponds to 489958"},"testStepId":"1"},"sequenceNumber":44,"timestamp":"2023-05-01T15:43:11Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Region mask: 0x1"},"testStepId":"1"},"sequenceNumber":45,"timestamp":"2023-05-01T15:43:11Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"1"},"sequenceNumber":46,"timestamp":"2023-05-01T15:43:11Z"}
{"testStepArtifact":{"testStepStart":{"name":"Run Memory Copy Threads"},"testStepId":"2"},"sequenceNumber":47,"timestamp":"2023-05-01T15:43:11Z"}
{"testStepArtifact":{"testStepStart":{"name":"Run Memory Invert Threads"},"testStepId":"3"},"sequenceNumber":48,"timestamp":"2023-05-01T15:43:11Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Starting memory invert threads"},"testStepId":"3"},"sequenceNumber":49,"timestamp":"2023-05-01T15:43:11Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Invert Thread #1: Starting memory invert thread"},"testStepId":"3"},"sequenceNumber":50,"timestamp":"2023-05-01T15:43:11Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Copy Thread #0: Starting memory copy thread. CPU: 1, Mem: ffffffff, Warming: No, Has Vector: Yes"},"testStepId":"2"},"sequenceNumber":51,"timestamp":"2023-05-01T15:43:11Z"}
2023/05/01-15:43:21(UTC) Log: Seconds remaining: 10
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Invert Thread #1: Invert thread completed with status 1 and 119662 pages copied"},"testStepId":"3"},"sequenceNumber":52,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Copy Thread #0: Status: Success, 188853 pages copied."},"testStepId":"2"},"sequenceNumber":53,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"testStepStart":{"name":"Run Post-Test Memory Check Threads"},"testStepId":"4"},"sequenceNumber":54,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Finished countdown, beginning to check results"},"testStepId":"4"},"sequenceNumber":55,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 2"},"testStepId":"4"},"sequenceNumber":56,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 3"},"testStepId":"4"},"sequenceNumber":57,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 4"},"testStepId":"4"},"sequenceNumber":58,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #2: Starting Check thread"},"testStepId":"4"},"sequenceNumber":59,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #3: Starting Check thread"},"testStepId":"4"},"sequenceNumber":60,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 5"},"testStepId":"4"},"sequenceNumber":61,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #4: Starting Check thread"},"testStepId":"4"},"sequenceNumber":62,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 6"},"testStepId":"4"},"sequenceNumber":63,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #5: Starting Check thread"},"testStepId":"4"},"sequenceNumber":64,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 7"},"testStepId":"4"},"sequenceNumber":65,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #6: Starting Check thread"},"testStepId":"4"},"sequenceNumber":66,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 8"},"testStepId":"4"},"sequenceNumber":67,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #7: Starting Check thread"},"testStepId":"4"},"sequenceNumber":68,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 9"},"testStepId":"4"},"sequenceNumber":69,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #8: Starting Check thread"},"testStepId":"4"},"sequenceNumber":70,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 2"},"testStepId":"4"},"sequenceNumber":71,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #9: Starting Check thread"},"testStepId":"4"},"sequenceNumber":72,"timestamp":"2023-05-01T15:43:31Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #3: Check thread completed with status 1, 38681 pages copied"},"testStepId":"4"},"sequenceNumber":73,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #6: Check thread completed with status 1, 39051 pages copied"},"testStepId":"4"},"sequenceNumber":74,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #4: Check thread completed with status 1, 39031 pages copied"},"testStepId":"4"},"sequenceNumber":75,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #7: Check thread completed with status 1, 32077 pages copied"},"testStepId":"4"},"sequenceNumber":76,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #2: Check thread completed with status 1, 33251 pages copied"},"testStepId":"4"},"sequenceNumber":77,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #9: Check thread completed with status 1, 32186 pages copied"},"testStepId":"4"},"sequenceNumber":78,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 3"},"testStepId":"4"},"sequenceNumber":79,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 4"},"testStepId":"4"},"sequenceNumber":80,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 5"},"testStepId":"4"},"sequenceNumber":81,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #8: Check thread completed with status 1, 40740 pages copied"},"testStepId":"4"},"sequenceNumber":82,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #5: Check thread completed with status 1, 38959 pages copied"},"testStepId":"4"},"sequenceNumber":83,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 6"},"testStepId":"4"},"sequenceNumber":84,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 7"},"testStepId":"4"},"sequenceNumber":85,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 8"},"testStepId":"4"},"sequenceNumber":86,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 9"},"testStepId":"4"},"sequenceNumber":87,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 2"},"testStepId":"4"},"sequenceNumber":88,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 2 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":89,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 3"},"testStepId":"4"},"sequenceNumber":90,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 3 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":91,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 4"},"testStepId":"4"},"sequenceNumber":92,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 4 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":93,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 5"},"testStepId":"4"},"sequenceNumber":94,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 5 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":95,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 6"},"testStepId":"4"},"sequenceNumber":96,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 6 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":97,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 7"},"testStepId":"4"},"sequenceNumber":98,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 7 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":99,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 8"},"testStepId":"4"},"sequenceNumber":100,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 8 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":101,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 9"},"testStepId":"4"},"sequenceNumber":102,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 9 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":103,"timestamp":"2023-05-01T15:43:34Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"4"},"sequenceNumber":104,"timestamp":"2023-05-01T15:43:34Z"}
2023/05/01-15:43:34(UTC) Stats: Found 0 hardware incidents
2023/05/01-15:43:34(UTC) Stats: Completed: 856354.00M in 20.00s 42815.43MB/s, with 0 hardware incidents, 0 errors
2023/05/01-15:43:34(UTC) Stats: Memory Copy: 377706.00M at 18884.30MB/s
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"2"},"sequenceNumber":105,"timestamp":"2023-05-01T15:43:34Z"}
2023/05/01-15:43:34(UTC) Stats: File Copy: 0.00M at 0.00MB/s
2023/05/01-15:43:34(UTC) Stats: Net Copy: 0.00M at 0.00MB/s
2023/05/01-15:43:34(UTC) Stats: Data Check: 0.00M at 0.00MB/s
2023/05/01-15:43:34(UTC) Stats: Invert Data: 478648.00M at 23931.36MB/s
2023/05/01-15:43:34(UTC) Stats: Disk: 0.00M at 0.00MB/s
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"3"},"sequenceNumber":106,"timestamp":"2023-05-01T15:43:34Z"}
2023/05/01-15:43:34(UTC)
2023/05/01-15:43:34(UTC) Status: PASS - please verify no corrected errors
2023/05/01-15:43:34(UTC)
{"testRunArtifact":{"testRunEnd":{"status":"COMPLETE","result":"PASS"}},"sequenceNumber":107,"timestamp":"2023-05-01T15:43:36Z"}
```