### PR TITLE
Converted all cpu cache coherency test threads to ocp diag format

### DIFF
--- a/src/sat.cc
+++ b/src/sat.cc
@@ -1460,11 +1460,13 @@ void Sat::InitializeThreads() {
 
   // CPU Cache Coherency Threads - one for each core available.
   if (cc_test_) {
-    // TODO(b/274522913) Populate CPU cache coherency step
     auto cpu_cache_step =
         std::make_unique<TestStep>("Run CPU Cache Coherency Test", *test_run_);
     WorkerVector *cc_vector = new WorkerVector();
-    logprintf(12, "Log: Starting cpu cache coherency threads\n");
+    cpu_cache_step->AddLog(Log{
+        .severity = LogSeverity::kDebug,
+        .message = "Starting cpu cache coherency threads",
+    });
 
     // Allocate the shared datastructure to be worked on by the threads.
     cc_cacheline_data_ = reinterpret_cast<cc_cacheline_data *>(
@@ -1483,8 +1485,12 @@ void Sat::InitializeThreads() {
     if (line_size <= 0) {
       line_size = CacheLineSize();
       if (line_size < kCacheLineSize) line_size = kCacheLineSize;
-      logprintf(12, "Log: Using %d as cache line size\n", line_size);
     }
+    cpu_cache_step->AddMeasurement(Measurement{
+        .name = "Cache Line Size",
+        .unit = "bytes",
+        .value = static_cast<double>(line_size),
+    });
     // The number of cache lines needed to hold an array of num_cpus.
     // "num" must be the same type as cc_cacheline_data[X].num or the memory
     // size calculations will fail.

--- a/src/sat.h
+++ b/src/sat.h
@@ -32,13 +32,17 @@ constexpr char kFileWriteFailVerdict[] = "sat-file-write-fail";
 constexpr char kFileReadFailVerdict[] = "sat-file-read-fail";
 constexpr char kHddSectorTagFailVerdict[] = "sat-hdd-sector-tag-fail";
 constexpr char kHddMiscompareFailVerdict[] = "sat-hdd-crc-miscompare-fail";
-constexpr char kGeneralMiscompareFailVerdict[] = "sat-general-crc-miscompare-fail";
+constexpr char kGeneralMiscompareFailVerdict[] =
+    "sat-general-crc-miscompare-fail";
 
 constexpr char kDeviceSizeZeroFailVerdict[] = "sat-device-size-zero-fail";
 constexpr char kDiskPatternMismatchFailVerdict[] = "sat-disk-pattern-mismatch";
-constexpr char kDiskAsyncOperationTimeoutFailVerdict[] = "sat-disk-async-operation-timeout-fail";
+constexpr char kDiskAsyncOperationTimeoutFailVerdict[] =
+    "sat-disk-async-operation-timeout-fail";
 constexpr char kDiskUnknownFailVerdict[] = "sat-disk-unknown-error-fail";
 constexpr char kDiskLowLevelIOFailVerdict[] = "sat-disk-low-level-io-fail";
+
+constexpr char kCacheCoherencyFailVerdict[] = "sat-cache-coherency-fail";
 
 // SAT stress test class.
 class Sat {

--- a/src/worker.h
+++ b/src/worker.h
@@ -622,6 +622,8 @@ class CpuCacheCoherencyThread : public WorkerThread {
                           int cc_inc_count_);
   virtual bool Work();
 
+  string GetThreadTypeName() { return "CPU Cache Coherency Thread"; }
+
  protected:
   // Used by the simple random number generator as a shift feedback;
   // this polynomial (x^64 + x^63 + x^61 + x^60 + 1) will produce a


### PR DESCRIPTION
Internal Reference: 274522913

Tested:
```
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #3: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":56,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #5: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":57,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #2: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":58,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #7: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":59,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #25: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":60,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #29: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":61,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #29: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":62,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #35: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":63,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #39: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":64,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #43: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":65,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #45: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":66,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #54: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":67,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #56: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":68,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #10: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":69,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #6: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":70,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #72: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":71,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #75: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":72,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #75: Requested CPUs 4000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":73,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #75: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":74,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #4: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":75,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #16: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":76,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #90: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":77,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #90: Requested CPUs 20000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":78,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #90: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":79,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #96: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":80,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #96: Requested CPUs 800000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":81,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #96: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":82,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #18: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":83,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #103: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":84,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #103: Requested CPUs 40000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":85,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #103: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":86,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #2: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":87,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #24: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":88,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #23: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":89,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #118: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":90,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #118: Requested CPUs 200000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":91,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #118: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":92,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #28: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":93,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #127: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":94,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #127: Requested CPUs 40000000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":95,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #127: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":96,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #32: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":97,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #33: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":98,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #36: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":99,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #34: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":100,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #37: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":101,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #38: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":102,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #41: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":103,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #35: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":104,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #40: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":105,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #42: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":106,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #39: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":107,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #44: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":108,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #48: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":109,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #43: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":110,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #50: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":111,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #46: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":112,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #46: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":113,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #51: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":114,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #52: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":115,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #49: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":116,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #53: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":117,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #1: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":118,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #8: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":119,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #55: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":120,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #45: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":121,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #57: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":122,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #9: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":123,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #58: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":124,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #54: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":125,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #61: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":126,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #60: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":127,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #59: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":128,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #62: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":129,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #63: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":130,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #64: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":131,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #56: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":132,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #66: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":133,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #66: Requested CPUs 20000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":134,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #70: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":135,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #70: Requested CPUs 200000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":136,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #70: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":137,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #69: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":138,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #69: Requested CPUs 100000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":139,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #69: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":140,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #12: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":141,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #73: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":142,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #73: Requested CPUs 1000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":143,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #73: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":144,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #11: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":145,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #76: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":146,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #76: Requested CPUs 8000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":147,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #76: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":148,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #13: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":149,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #79: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":150,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #79: Requested CPUs 40000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":151,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #79: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":152,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #14: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":153,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #82: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":154,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #82: Requested CPUs 200000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":155,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #82: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":156,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #83: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":157,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #83: Requested CPUs 400000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":158,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #83: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":159,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #87: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":160,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #87: Requested CPUs 4000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":161,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #87: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":162,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #16: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":163,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #91: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":164,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #91: Requested CPUs 40000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":165,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #91: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":166,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #17: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":167,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #94: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":168,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #94: Requested CPUs 200000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":169,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #94: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":170,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #44: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":171,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #95: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":172,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #95: Requested CPUs 400000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":173,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #95: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":174,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #20: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":175,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #98: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":176,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #98: Requested CPUs 2000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":177,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #98: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":178,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #99: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":179,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #99: Requested CPUs 4000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":180,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #99: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":181,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #5: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":182,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #104: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":183,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #104: Requested CPUs 80000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":184,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #104: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":185,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #106: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":186,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #106: Requested CPUs 200000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":187,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #106: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":188,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #107: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":189,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #109: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":190,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #109: Requested CPUs 1000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":191,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #109: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":192,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #114: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":193,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #114: Requested CPUs 20000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":194,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #114: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":195,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #113: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":196,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #113: Requested CPUs 10000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":197,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #113: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":198,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #7: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":199,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #23: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":200,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #119: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":201,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #119: Requested CPUs 400000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":202,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #119: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":203,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #121: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":204,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #121: Requested CPUs 1000000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":205,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #121: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":206,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #124: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":207,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #124: Requested CPUs 8000000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":208,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #124: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":209,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #126: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":210,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #126: Requested CPUs 20000000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":211,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #126: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":212,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #17: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":213,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #107: Requested CPUs 400000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":214,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #107: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":215,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #25: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":216,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #128: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":217,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #128: Requested CPUs 80000000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":218,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #128: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":219,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #31: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":220,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #32: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":221,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #33: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":222,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #36: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":223,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #34: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":224,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #37: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":225,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #38: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":226,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #41: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":227,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #42: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":228,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #48: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":229,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #50: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":230,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #47: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":231,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #51: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":232,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #52: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":233,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #49: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":234,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #53: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":235,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #8: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":236,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #55: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":237,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #57: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":238,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #9: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":239,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #58: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":240,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #60: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":241,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #59: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":242,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #62: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":243,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #63: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":244,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #64: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":245,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #10: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":246,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #66: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":247,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #67: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":248,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #67: Requested CPUs 40000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":249,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #67: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":250,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #68: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":251,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #68: Requested CPUs 80000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":252,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #68: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":253,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #71: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":254,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #71: Requested CPUs 400000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":255,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #71: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":256,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #72: Requested CPUs 800000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":257,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #72: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":258,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #77: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":259,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #77: Requested CPUs 10000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":260,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #77: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":261,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #40: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":262,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #81: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":263,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #81: Requested CPUs 100000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":264,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #81: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":265,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #14: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":266,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #84: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":267,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #84: Requested CPUs 800000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":268,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #84: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":269,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #85: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":270,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #85: Requested CPUs 1000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":271,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #85: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":272,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #89: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":273,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #89: Requested CPUs 10000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":274,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #89: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":275,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #93: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":276,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #93: Requested CPUs 100000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":277,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #93: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":278,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #19: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":279,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #13: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":280,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #61: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":281,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #21: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":282,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #97: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":283,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #97: Requested CPUs 1000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":284,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #97: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":285,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #100: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":286,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #100: Requested CPUs 8000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":287,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #100: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":288,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #18: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":289,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #22: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":290,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #105: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":291,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #105: Requested CPUs 100000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":292,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #105: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":293,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #111: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":294,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #111: Requested CPUs 4000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":295,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #111: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":296,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #115: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":297,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #115: Requested CPUs 40000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":298,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #115: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":299,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #120: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":300,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #120: Requested CPUs 800000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":301,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #120: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":302,"timestamp":"2023-05-01T20:45:29Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #122: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":303,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #122: Requested CPUs 2000000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":304,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #122: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":305,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #27: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":306,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #125: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":307,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #28: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":308,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #30: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":309,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #31: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":310,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #47: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":311,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #65: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":312,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #65: Requested CPUs 10000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":313,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #65: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":314,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #11: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":315,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #78: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":316,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #78: Requested CPUs 20000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":317,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #78: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":318,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #86: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":319,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #86: Requested CPUs 2000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":320,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #86: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":321,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #88: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":322,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #88: Requested CPUs 8000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":323,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #88: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":324,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #19: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":325,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #21: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":326,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #20: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":327,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #3: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":328,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #102: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":329,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #102: Requested CPUs 20000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":330,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #102: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":331,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #108: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":332,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #108: Requested CPUs 800000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":333,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #108: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":334,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #24: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":335,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #116: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":336,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #116: Requested CPUs 80000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":337,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #116: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":338,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #123: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":339,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #123: Requested CPUs 4000000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":340,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #123: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":341,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #30: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":342,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #12: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":343,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #74: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":344,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #74: Requested CPUs 2000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":345,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #74: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":346,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #92: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":347,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #92: Requested CPUs 80000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":348,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #92: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":349,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #110: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":350,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #110: Requested CPUs 2000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":351,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #110: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":352,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #117: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":353,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #117: Requested CPUs 100000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":354,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #117: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":355,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #27: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":356,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #80: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":357,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #80: Requested CPUs 80000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":358,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #80: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":359,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #15: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":360,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #101: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":361,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #101: Requested CPUs 10000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":362,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #101: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":363,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #26: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":364,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #125: Requested CPUs 10000000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":365,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #125: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":366,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #22: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":367,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #112: Available CPU mask - FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":368,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"WARNING","message":"CPU Cache Coherency Thread #112: Requested CPUs 8000000000000000000000000000 not a subset of available FFFFFFFFFFFFFFFF"},"testStepId":"3"},"sequenceNumber":369,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #112: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":370,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #26: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":371,"timestamp":"2023-05-01T20:45:30Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #15: Starting the Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":372,"timestamp":"2023-05-01T20:45:30Z"}
2023/05/01-20:45:39(UTC) Log: Seconds remaining: 10
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 82 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19990706},"testStepId":"3"},"sequenceNumber":373,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 31 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19967366},"testStepId":"3"},"sequenceNumber":374,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 31 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":14519000},"testStepId":"3"},"sequenceNumber":375,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 31 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":727136.468575775},"testStepId":"3"},"sequenceNumber":376,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #32: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":377,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Copy Thread #0: Status: Success, 96770 pages copied."},"testStepId":"2"},"sequenceNumber":378,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 40 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19966085},"testStepId":"3"},"sequenceNumber":379,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 40 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":19320000},"testStepId":"3"},"sequenceNumber":380,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 40 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":967640.877017202},"testStepId":"3"},"sequenceNumber":381,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #41: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":382,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 79 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19823051},"testStepId":"3"},"sequenceNumber":383,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 79 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16424000},"testStepId":"3"},"sequenceNumber":384,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 79 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":828530.381120444},"testStepId":"3"},"sequenceNumber":385,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #80: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":386,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 114 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19878283},"testStepId":"3"},"sequenceNumber":387,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 114 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16096000},"testStepId":"3"},"sequenceNumber":388,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 114 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":809727.88243330678},"testStepId":"3"},"sequenceNumber":389,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #115: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":390,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 1 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":20002349},"testStepId":"3"},"sequenceNumber":391,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 1 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":18960000},"testStepId":"3"},"sequenceNumber":392,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 1 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":947888.67047565267},"testStepId":"3"},"sequenceNumber":393,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #2: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":394,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 72 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19992861},"testStepId":"3"},"sequenceNumber":395,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 72 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11300000},"testStepId":"3"},"sequenceNumber":396,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 72 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":565201.74876422144},"testStepId":"3"},"sequenceNumber":397,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #73: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":398,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 74 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":20004858},"testStepId":"3"},"sequenceNumber":399,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 74 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17171000},"testStepId":"3"},"sequenceNumber":400,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 74 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":858341.5088475009},"testStepId":"3"},"sequenceNumber":401,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #75: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":402,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 33 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19966479},"testStepId":"3"},"sequenceNumber":403,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 33 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":19023000},"testStepId":"3"},"sequenceNumber":404,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 33 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":952746.85136022232},"testStepId":"3"},"sequenceNumber":405,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #34: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":406,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 4 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19983825},"testStepId":"3"},"sequenceNumber":407,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 4 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":12931000},"testStepId":"3"},"sequenceNumber":408,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 4 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":647073.32054799318},"testStepId":"3"},"sequenceNumber":409,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #5: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":410,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 76 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19935185},"testStepId":"3"},"sequenceNumber":411,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 76 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16615000},"testStepId":"3"},"sequenceNumber":412,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 76 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":833451.006348825},"testStepId":"3"},"sequenceNumber":413,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #77: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":414,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 37 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19966520},"testStepId":"3"},"sequenceNumber":415,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 37 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16913000},"testStepId":"3"},"sequenceNumber":416,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 37 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":847067.99181830382},"testStepId":"3"},"sequenceNumber":417,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #38: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":418,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 54 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19955157},"testStepId":"3"},"sequenceNumber":419,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 54 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":18092000},"testStepId":"3"},"sequenceNumber":420,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 54 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":906632.80674764921},"testStepId":"3"},"sequenceNumber":421,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #55: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":422,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 81 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19991414},"testStepId":"3"},"sequenceNumber":423,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 81 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16419000},"testStepId":"3"},"sequenceNumber":424,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 81 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":821302.58519982628},"testStepId":"3"},"sequenceNumber":425,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #82: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":426,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 46 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19866891},"testStepId":"3"},"sequenceNumber":427,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 46 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16603000},"testStepId":"3"},"sequenceNumber":428,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 46 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":835712.03969458537},"testStepId":"3"},"sequenceNumber":429,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #47: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":430,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 78 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19991982},"testStepId":"3"},"sequenceNumber":431,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 78 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":15300000},"testStepId":"3"},"sequenceNumber":432,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 78 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":765306.81150073069},"testStepId":"3"},"sequenceNumber":433,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #79: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":434,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 98 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19984318},"testStepId":"3"},"sequenceNumber":435,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 98 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17012000},"testStepId":"3"},"sequenceNumber":436,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 98 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":851267.47883015068},"testStepId":"3"},"sequenceNumber":437,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #99: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":438,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 59 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19954535},"testStepId":"3"},"sequenceNumber":439,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 59 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17387000},"testStepId":"3"},"sequenceNumber":440,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 59 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":871330.75263342389},"testStepId":"3"},"sequenceNumber":441,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #60: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":442,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 5 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":20005975},"testStepId":"3"},"sequenceNumber":443,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 5 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":14400000},"testStepId":"3"},"sequenceNumber":444,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 5 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":719784.96424193273},"testStepId":"3"},"sequenceNumber":445,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #6: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":446,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 126 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":20000598},"testStepId":"3"},"sequenceNumber":447,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 126 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16512000},"testStepId":"3"},"sequenceNumber":448,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 126 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":825575.31529807264},"testStepId":"3"},"sequenceNumber":449,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #127: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":450,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 39 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19935297},"testStepId":"3"},"sequenceNumber":451,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 39 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16161000},"testStepId":"3"},"sequenceNumber":452,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 39 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":810672.64761593472},"testStepId":"3"},"sequenceNumber":453,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #40: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":454,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 36 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19966358},"testStepId":"3"},"sequenceNumber":455,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 36 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17246000},"testStepId":"3"},"sequenceNumber":456,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 36 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":863752.91878468776},"testStepId":"3"},"sequenceNumber":457,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #37: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":458,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 38 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19998767},"testStepId":"3"},"sequenceNumber":459,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 38 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17494000},"testStepId":"3"},"sequenceNumber":460,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 38 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":874753.92857969692},"testStepId":"3"},"sequenceNumber":461,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #39: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":462,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 58 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19954517},"testStepId":"3"},"sequenceNumber":463,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 58 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16993000},"testStepId":"3"},"sequenceNumber":464,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 58 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":851586.63574768556},"testStepId":"3"},"sequenceNumber":465,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #59: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":466,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 16 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19980146},"testStepId":"3"},"sequenceNumber":467,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 16 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11023000},"testStepId":"3"},"sequenceNumber":468,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 16 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":551697.67027728423},"testStepId":"3"},"sequenceNumber":469,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #17: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":470,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 25 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19811000},"testStepId":"3"},"sequenceNumber":471,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 25 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11404000},"testStepId":"3"},"sequenceNumber":472,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 25 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":575639.79607288877},"testStepId":"3"},"sequenceNumber":473,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #26: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":474,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 116 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19824103},"testStepId":"3"},"sequenceNumber":475,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 116 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16422000},"testStepId":"3"},"sequenceNumber":476,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 116 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":828385.52644727484},"testStepId":"3"},"sequenceNumber":477,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #117: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":478,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 8 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19955140},"testStepId":"3"},"sequenceNumber":479,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 8 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":9868000},"testStepId":"3"},"sequenceNumber":480,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 8 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":494509.18409993616},"testStepId":"3"},"sequenceNumber":481,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #9: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":482,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 123 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19980316},"testStepId":"3"},"sequenceNumber":483,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 123 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11319000},"testStepId":"3"},"sequenceNumber":484,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 123 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":566507.55673734087},"testStepId":"3"},"sequenceNumber":485,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #124: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":486,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 29 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19836272},"testStepId":"3"},"sequenceNumber":487,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 29 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":12011000},"testStepId":"3"},"sequenceNumber":488,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 29 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":605506.921865157},"testStepId":"3"},"sequenceNumber":489,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #30: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":490,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 34 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19999417},"testStepId":"3"},"sequenceNumber":491,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 34 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":21441000},"testStepId":"3"},"sequenceNumber":492,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 34 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":1072081.2511684715},"testStepId":"3"},"sequenceNumber":493,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #35: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":494,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 30 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19867350},"testStepId":"3"},"sequenceNumber":495,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 30 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11694000},"testStepId":"3"},"sequenceNumber":496,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 30 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":588603.91546935041},"testStepId":"3"},"sequenceNumber":497,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #31: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":498,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 11 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19836133},"testStepId":"3"},"sequenceNumber":499,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 11 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11352000},"testStepId":"3"},"sequenceNumber":500,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 11 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":572288.96378139837},"testStepId":"3"},"sequenceNumber":501,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #12: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":502,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 44 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19996014},"testStepId":"3"},"sequenceNumber":503,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 44 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16199000},"testStepId":"3"},"sequenceNumber":504,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 44 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":810111.45521302393},"testStepId":"3"},"sequenceNumber":505,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #45: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":506,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 48 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19955463},"testStepId":"3"},"sequenceNumber":507,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 48 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17357000},"testStepId":"3"},"sequenceNumber":508,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 48 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":869786.88492469455},"testStepId":"3"},"sequenceNumber":509,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #49: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":510,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 89 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":20003736},"testStepId":"3"},"sequenceNumber":511,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 89 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16769000},"testStepId":"3"},"sequenceNumber":512,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 89 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":838293.40679161134},"testStepId":"3"},"sequenceNumber":513,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #90: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":514,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 3 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":20004510},"testStepId":"3"},"sequenceNumber":515,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 3 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":18810000},"testStepId":"3"},"sequenceNumber":516,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 3 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":940287.9650638781},"testStepId":"3"},"sequenceNumber":517,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #4: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":518,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 52 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19955480},"testStepId":"3"},"sequenceNumber":519,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 52 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":18715000},"testStepId":"3"},"sequenceNumber":520,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 52 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":937837.62655671523},"testStepId":"3"},"sequenceNumber":521,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #53: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":522,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 109 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19834702},"testStepId":"3"},"sequenceNumber":523,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 109 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16021000},"testStepId":"3"},"sequenceNumber":524,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 109 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":807725.77273911145},"testStepId":"3"},"sequenceNumber":525,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #110: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":526,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 93 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19989614},"testStepId":"3"},"sequenceNumber":527,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 93 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11263000},"testStepId":"3"},"sequenceNumber":528,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 93 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":563442.59573996777},"testStepId":"3"},"sequenceNumber":529,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #94: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":530,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 103 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19983464},"testStepId":"3"},"sequenceNumber":531,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 103 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17661000},"testStepId":"3"},"sequenceNumber":532,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 103 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":883780.70989093778},"testStepId":"3"},"sequenceNumber":533,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #104: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":534,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 75 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19992415},"testStepId":"3"},"sequenceNumber":535,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 75 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11092000},"testStepId":"3"},"sequenceNumber":536,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 75 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":554810.41184869362},"testStepId":"3"},"sequenceNumber":537,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #76: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":538,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 35 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19966945},"testStepId":"3"},"sequenceNumber":539,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 35 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":20110000},"testStepId":"3"},"sequenceNumber":540,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 35 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":1007164.5912782351},"testStepId":"3"},"sequenceNumber":541,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #36: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":542,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 104 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19879230},"testStepId":"3"},"sequenceNumber":543,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 104 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":15720000},"testStepId":"3"},"sequenceNumber":544,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 104 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":790775.09541365539},"testStepId":"3"},"sequenceNumber":545,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #105: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":546,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 23 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19845326},"testStepId":"3"},"sequenceNumber":547,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 23 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11208000},"testStepId":"3"},"sequenceNumber":548,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 23 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":564767.74430412485},"testStepId":"3"},"sequenceNumber":549,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #24: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":550,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 66 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19943833},"testStepId":"3"},"sequenceNumber":551,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 66 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16781000},"testStepId":"3"},"sequenceNumber":552,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 66 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":841412.98214841646},"testStepId":"3"},"sequenceNumber":553,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #67: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":554,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 107 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19845565},"testStepId":"3"},"sequenceNumber":555,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 107 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16288000},"testStepId":"3"},"sequenceNumber":556,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 107 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":820737.53002245084},"testStepId":"3"},"sequenceNumber":557,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #108: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":558,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 64 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19866665},"testStepId":"3"},"sequenceNumber":559,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 64 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10945000},"testStepId":"3"},"sequenceNumber":560,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 64 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":550922.86501030752},"testStepId":"3"},"sequenceNumber":561,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #65: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":562,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 19 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19851412},"testStepId":"3"},"sequenceNumber":563,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 19 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11824000},"testStepId":"3"},"sequenceNumber":564,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 19 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":595625.13739576808},"testStepId":"3"},"sequenceNumber":565,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #20: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":566,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 56 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19954631},"testStepId":"3"},"sequenceNumber":567,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 56 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":15062000},"testStepId":"3"},"sequenceNumber":568,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 56 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":754812.25385726255},"testStepId":"3"},"sequenceNumber":569,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #57: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":570,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 63 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19954072},"testStepId":"3"},"sequenceNumber":571,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 63 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17935000},"testStepId":"3"},"sequenceNumber":572,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 63 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":898814.03655354155},"testStepId":"3"},"sequenceNumber":573,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #64: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":574,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 96 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19891943},"testStepId":"3"},"sequenceNumber":575,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 96 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10426000},"testStepId":"3"},"sequenceNumber":576,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 96 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":524131.80552548333},"testStepId":"3"},"sequenceNumber":577,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #97: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":578,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 9 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19953974},"testStepId":"3"},"sequenceNumber":579,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 9 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11458000},"testStepId":"3"},"sequenceNumber":580,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 9 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":574221.4558363161},"testStepId":"3"},"sequenceNumber":581,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #10: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":582,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 102 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":20003144},"testStepId":"3"},"sequenceNumber":583,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 102 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16633000},"testStepId":"3"},"sequenceNumber":584,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 102 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":831519.28516837151},"testStepId":"3"},"sequenceNumber":585,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #103: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":586,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 7 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19955657},"testStepId":"3"},"sequenceNumber":587,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 7 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":14123000},"testStepId":"3"},"sequenceNumber":588,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 7 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":707719.119445679},"testStepId":"3"},"sequenceNumber":589,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #8: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":590,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 14 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19810971},"testStepId":"3"},"sequenceNumber":591,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 14 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10704000},"testStepId":"3"},"sequenceNumber":592,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 14 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":540306.68158567289},"testStepId":"3"},"sequenceNumber":593,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #15: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":594,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 43 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19988356},"testStepId":"3"},"sequenceNumber":595,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 43 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":18414000},"testStepId":"3"},"sequenceNumber":596,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 43 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":921236.34379936},"testStepId":"3"},"sequenceNumber":597,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #44: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":598,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 124 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19811840},"testStepId":"3"},"sequenceNumber":599,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 124 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11291000},"testStepId":"3"},"sequenceNumber":600,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 124 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":569911.72955162171},"testStepId":"3"},"sequenceNumber":601,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #125: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":602,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 92 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19914938},"testStepId":"3"},"sequenceNumber":603,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 92 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":13265000},"testStepId":"3"},"sequenceNumber":604,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 92 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":666082.91725537879},"testStepId":"3"},"sequenceNumber":605,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #93: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":606,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 55 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19994243},"testStepId":"3"},"sequenceNumber":607,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 55 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":21387000},"testStepId":"3"},"sequenceNumber":608,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 55 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":1069657.9010268105},"testStepId":"3"},"sequenceNumber":609,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #56: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":610,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 100 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19811484},"testStepId":"3"},"sequenceNumber":611,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 100 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10858000},"testStepId":"3"},"sequenceNumber":612,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 100 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":548065.96012696472},"testStepId":"3"},"sequenceNumber":613,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #101: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":614,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 68 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19993436},"testStepId":"3"},"sequenceNumber":615,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 68 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11270000},"testStepId":"3"},"sequenceNumber":616,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 68 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":563685.00141746516},"testStepId":"3"},"sequenceNumber":617,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #69: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":618,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 0 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19996688},"testStepId":"3"},"sequenceNumber":619,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 0 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10020000},"testStepId":"3"},"sequenceNumber":620,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 0 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":501082.97934137896},"testStepId":"3"},"sequenceNumber":621,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #1: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":622,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 111 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19810832},"testStepId":"3"},"sequenceNumber":623,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 111 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11347000},"testStepId":"3"},"sequenceNumber":624,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 111 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":572767.46377941116},"testStepId":"3"},"sequenceNumber":625,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #112: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":626,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 73 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19835460},"testStepId":"3"},"sequenceNumber":627,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 73 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16787000},"testStepId":"3"},"sequenceNumber":628,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 73 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":846312.61387434427},"testStepId":"3"},"sequenceNumber":629,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #74: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":630,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 13 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19923991},"testStepId":"3"},"sequenceNumber":631,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 13 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11270000},"testStepId":"3"},"sequenceNumber":632,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 13 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":565649.72349164379},"testStepId":"3"},"sequenceNumber":633,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #14: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":634,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 45 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19997691},"testStepId":"3"},"sequenceNumber":635,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 45 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17729000},"testStepId":"3"},"sequenceNumber":636,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 45 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":886552.35246909258},"testStepId":"3"},"sequenceNumber":637,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #46: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":638,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 117 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":20001287},"testStepId":"3"},"sequenceNumber":639,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 117 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16368000},"testStepId":"3"},"sequenceNumber":640,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 117 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":818347.33934871294},"testStepId":"3"},"sequenceNumber":641,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #118: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":642,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 120 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19980888},"testStepId":"3"},"sequenceNumber":643,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 120 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":12147000},"testStepId":"3"},"sequenceNumber":644,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 120 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":607930.93880512216},"testStepId":"3"},"sequenceNumber":645,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #121: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":646,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 90 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19990418},"testStepId":"3"},"sequenceNumber":647,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 90 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10959000},"testStepId":"3"},"sequenceNumber":648,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 90 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":548212.64867998252},"testStepId":"3"},"sequenceNumber":649,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #91: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":650,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 105 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19983421},"testStepId":"3"},"sequenceNumber":651,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 105 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11700000},"testStepId":"3"},"sequenceNumber":652,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 105 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":585485.33807099389},"testStepId":"3"},"sequenceNumber":653,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #106: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":654,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 53 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19995927},"testStepId":"3"},"sequenceNumber":655,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 53 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":18629000},"testStepId":"3"},"sequenceNumber":656,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 53 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":931639.7284306949},"testStepId":"3"},"sequenceNumber":657,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #54: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":658,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 106 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19976018},"testStepId":"3"},"sequenceNumber":659,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 106 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":12433000},"testStepId":"3"},"sequenceNumber":660,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 106 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":622396.31542182236},"testStepId":"3"},"sequenceNumber":661,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #107: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":662,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 57 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19954995},"testStepId":"3"},"sequenceNumber":663,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 57 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16168000},"testStepId":"3"},"sequenceNumber":664,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 57 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":810223.20476652589},"testStepId":"3"},"sequenceNumber":665,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #58: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":666,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 28 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":20009901},"testStepId":"3"},"sequenceNumber":667,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 28 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":13702000},"testStepId":"3"},"sequenceNumber":668,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 28 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":684761.00906246365},"testStepId":"3"},"sequenceNumber":669,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #29: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":670,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 91 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19835546},"testStepId":"3"},"sequenceNumber":671,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 91 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11032000},"testStepId":"3"},"sequenceNumber":672,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 91 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":556173.24574781058},"testStepId":"3"},"sequenceNumber":673,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #92: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":674,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 85 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19859487},"testStepId":"3"},"sequenceNumber":675,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 85 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":12115000},"testStepId":"3"},"sequenceNumber":676,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 85 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":610035.89871178439},"testStepId":"3"},"sequenceNumber":677,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #86: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":678,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 87 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19851531},"testStepId":"3"},"sequenceNumber":679,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 87 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10865000},"testStepId":"3"},"sequenceNumber":680,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 87 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":547312.95032106084},"testStepId":"3"},"sequenceNumber":681,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #88: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":682,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 26 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19823446},"testStepId":"3"},"sequenceNumber":683,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 26 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10360000},"testStepId":"3"},"sequenceNumber":684,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 26 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":522613.47497301933},"testStepId":"3"},"sequenceNumber":685,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #27: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":686,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 121 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19867674},"testStepId":"3"},"sequenceNumber":687,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 121 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11395000},"testStepId":"3"},"sequenceNumber":688,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 121 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":573544.74409032485},"testStepId":"3"},"sequenceNumber":689,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #122: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":690,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 86 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19990721},"testStepId":"3"},"sequenceNumber":691,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 86 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10475000},"testStepId":"3"},"sequenceNumber":692,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 86 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":523993.10660180793},"testStepId":"3"},"sequenceNumber":693,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #87: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":694,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 2 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19851110},"testStepId":"3"},"sequenceNumber":695,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 2 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":18309000},"testStepId":"3"},"sequenceNumber":696,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 2 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":922316.182823026},"testStepId":"3"},"sequenceNumber":697,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #3: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":698,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 125 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19979741},"testStepId":"3"},"sequenceNumber":699,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 125 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":12794000},"testStepId":"3"},"sequenceNumber":700,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 125 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":640348.641156059},"testStepId":"3"},"sequenceNumber":701,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #126: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":702,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 17 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19879750},"testStepId":"3"},"sequenceNumber":703,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 17 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10723000},"testStepId":"3"},"sequenceNumber":704,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 17 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":539393.101019882},"testStepId":"3"},"sequenceNumber":705,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #18: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":706,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 112 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19982063},"testStepId":"3"},"sequenceNumber":707,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 112 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16577000},"testStepId":"3"},"sequenceNumber":708,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 112 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":829594.02139809087},"testStepId":"3"},"sequenceNumber":709,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #113: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":710,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 61 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19954363},"testStepId":"3"},"sequenceNumber":711,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 61 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17755000},"testStepId":"3"},"sequenceNumber":712,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 61 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":889780.34528087918},"testStepId":"3"},"sequenceNumber":713,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #62: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":714,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 97 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19984806},"testStepId":"3"},"sequenceNumber":715,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 97 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16314000},"testStepId":"3"},"sequenceNumber":716,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 97 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":816320.158424355},"testStepId":"3"},"sequenceNumber":717,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #98: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":718,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 118 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19981417},"testStepId":"3"},"sequenceNumber":719,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 118 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":12157000},"testStepId":"3"},"sequenceNumber":720,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 118 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":608415.30908443581},"testStepId":"3"},"sequenceNumber":721,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #119: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":722,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 10 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19866649},"testStepId":"3"},"sequenceNumber":723,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 10 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":9987000},"testStepId":"3"},"sequenceNumber":724,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 10 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":502701.78931534954},"testStepId":"3"},"sequenceNumber":725,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #11: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":726,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 127 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19967240},"testStepId":"3"},"sequenceNumber":727,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 127 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":13056000},"testStepId":"3"},"sequenceNumber":728,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 127 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":653871.04076477268},"testStepId":"3"},"sequenceNumber":729,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #128: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":730,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 115 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19844617},"testStepId":"3"},"sequenceNumber":731,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 115 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11751000},"testStepId":"3"},"sequenceNumber":732,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 115 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":592150.50610450178},"testStepId":"3"},"sequenceNumber":733,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #116: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":734,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 6 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19981508},"testStepId":"3"},"sequenceNumber":735,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 6 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":12305000},"testStepId":"3"},"sequenceNumber":736,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 6 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":615819.38660485484},"testStepId":"3"},"sequenceNumber":737,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #7: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":738,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 88 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19915443},"testStepId":"3"},"sequenceNumber":739,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 88 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17581000},"testStepId":"3"},"sequenceNumber":740,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 88 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":882782.27102455113},"testStepId":"3"},"sequenceNumber":741,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #89: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":742,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 18 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19851568},"testStepId":"3"},"sequenceNumber":743,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 18 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10498000},"testStepId":"3"},"sequenceNumber":744,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 18 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":528824.72558338963},"testStepId":"3"},"sequenceNumber":745,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #19: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":746,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 101 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19848446},"testStepId":"3"},"sequenceNumber":747,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 101 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10971000},"testStepId":"3"},"sequenceNumber":748,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 101 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":552738.48642861},"testStepId":"3"},"sequenceNumber":749,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #102: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":750,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 99 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19879971},"testStepId":"3"},"sequenceNumber":751,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 99 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11120000},"testStepId":"3"},"sequenceNumber":752,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 99 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":559356.95278428728},"testStepId":"3"},"sequenceNumber":753,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #100: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":754,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 22 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19981711},"testStepId":"3"},"sequenceNumber":755,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 22 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10799000},"testStepId":"3"},"sequenceNumber":756,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 22 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":540444.20920710941},"testStepId":"3"},"sequenceNumber":757,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #23: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":758,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 51 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19956241},"testStepId":"3"},"sequenceNumber":759,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 51 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16989000},"testStepId":"3"},"sequenceNumber":760,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 51 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":851312.62946764368},"testStepId":"3"},"sequenceNumber":761,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #52: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":762,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 21 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19811560},"testStepId":"3"},"sequenceNumber":763,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 21 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11482000},"testStepId":"3"},"sequenceNumber":764,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 21 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":579560.62016317749},"testStepId":"3"},"sequenceNumber":765,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #22: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":766,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 94 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19984626},"testStepId":"3"},"sequenceNumber":767,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 94 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16393000},"testStepId":"3"},"sequenceNumber":768,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 94 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":820280.54965852248},"testStepId":"3"},"sequenceNumber":769,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #95: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":770,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 110 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19878658},"testStepId":"3"},"sequenceNumber":771,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 110 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":15866000},"testStepId":"3"},"sequenceNumber":772,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 110 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":798142.409814586},"testStepId":"3"},"sequenceNumber":773,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #111: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":774,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 41 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19966183},"testStepId":"3"},"sequenceNumber":775,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 41 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":18641000},"testStepId":"3"},"sequenceNumber":776,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 41 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":933628.62596220814},"testStepId":"3"},"sequenceNumber":777,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #42: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":778,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 62 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19953975},"testStepId":"3"},"sequenceNumber":779,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 62 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":18448000},"testStepId":"3"},"sequenceNumber":780,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 62 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":924527.56906831847},"testStepId":"3"},"sequenceNumber":781,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #63: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":782,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 70 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19935953},"testStepId":"3"},"sequenceNumber":783,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 70 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17213000},"testStepId":"3"},"sequenceNumber":784,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 70 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":863414.95688718767},"testStepId":"3"},"sequenceNumber":785,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #71: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":786,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 24 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19968139},"testStepId":"3"},"sequenceNumber":787,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 24 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11094000},"testStepId":"3"},"sequenceNumber":788,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 24 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":555585.07480341557},"testStepId":"3"},"sequenceNumber":789,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #25: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":790,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 20 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19851717},"testStepId":"3"},"sequenceNumber":791,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 20 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10975000},"testStepId":"3"},"sequenceNumber":792,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 20 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":552848.90470683214},"testStepId":"3"},"sequenceNumber":793,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #21: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":794,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 65 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19944382},"testStepId":"3"},"sequenceNumber":795,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 65 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17245000},"testStepId":"3"},"sequenceNumber":796,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 65 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":864654.51774840651},"testStepId":"3"},"sequenceNumber":797,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #66: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":798,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 95 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":20003344},"testStepId":"3"},"sequenceNumber":799,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 95 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":12486000},"testStepId":"3"},"sequenceNumber":800,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 95 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":624195.63448991324},"testStepId":"3"},"sequenceNumber":801,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #96: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":802,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 122 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19844552},"testStepId":"3"},"sequenceNumber":803,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 122 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16184000},"testStepId":"3"},"sequenceNumber":804,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 122 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":815538.69293698343},"testStepId":"3"},"sequenceNumber":805,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #123: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":806,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 42 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19998144},"testStepId":"3"},"sequenceNumber":807,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 42 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":18576000},"testStepId":"3"},"sequenceNumber":808,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 42 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":928886.20063941937},"testStepId":"3"},"sequenceNumber":809,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #43: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":810,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 77 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19866178},"testStepId":"3"},"sequenceNumber":811,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 77 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11016000},"testStepId":"3"},"sequenceNumber":812,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 77 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":554510.28375966428},"testStepId":"3"},"sequenceNumber":813,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #78: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":814,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 108 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19982949},"testStepId":"3"},"sequenceNumber":815,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 108 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10724000},"testStepId":"3"},"sequenceNumber":816,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 108 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":536657.52737496351},"testStepId":"3"},"sequenceNumber":817,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #109: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":818,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 32 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19967445},"testStepId":"3"},"sequenceNumber":819,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 32 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":21966000},"testStepId":"3"},"sequenceNumber":820,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 32 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":1100090.6725923121},"testStepId":"3"},"sequenceNumber":821,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #33: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":822,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 67 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19942729},"testStepId":"3"},"sequenceNumber":823,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 67 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16930000},"testStepId":"3"},"sequenceNumber":824,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 67 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":848930.95623974036},"testStepId":"3"},"sequenceNumber":825,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #68: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":826,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 50 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19956089},"testStepId":"3"},"sequenceNumber":827,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 50 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17663000},"testStepId":"3"},"sequenceNumber":828,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 50 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":885093.2665213109},"testStepId":"3"},"sequenceNumber":829,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #51: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":830,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 82 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":13800000},"testStepId":"3"},"sequenceNumber":831,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 82 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":690320.79207207588},"testStepId":"3"},"sequenceNumber":832,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #83: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":833,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 71 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19935847},"testStepId":"3"},"sequenceNumber":834,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 71 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":12111000},"testStepId":"3"},"sequenceNumber":835,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 71 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":607498.64302229043},"testStepId":"3"},"sequenceNumber":836,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #72: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":837,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 119 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19877983},"testStepId":"3"},"sequenceNumber":838,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 119 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":11126000},"testStepId":"3"},"sequenceNumber":839,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 119 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":559714.7356449595},"testStepId":"3"},"sequenceNumber":840,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #120: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":841,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 15 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19990624},"testStepId":"3"},"sequenceNumber":842,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 15 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":10830000},"testStepId":"3"},"sequenceNumber":843,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 15 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":541753.97426313453},"testStepId":"3"},"sequenceNumber":844,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #16: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":845,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 27 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19867619},"testStepId":"3"},"sequenceNumber":846,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 27 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":12075000},"testStepId":"3"},"sequenceNumber":847,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 27 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":607772.879075243},"testStepId":"3"},"sequenceNumber":848,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #28: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":849,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 80 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19934661},"testStepId":"3"},"sequenceNumber":850,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 80 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16381000},"testStepId":"3"},"sequenceNumber":851,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 80 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":821734.56573954283},"testStepId":"3"},"sequenceNumber":852,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #81: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":853,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 47 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19966331},"testStepId":"3"},"sequenceNumber":854,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 47 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16969000},"testStepId":"3"},"sequenceNumber":855,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 47 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":849880.73171781038},"testStepId":"3"},"sequenceNumber":856,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #48: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":857,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 83 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19923344},"testStepId":"3"},"sequenceNumber":858,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 83 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16683000},"testStepId":"3"},"sequenceNumber":859,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 83 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":837359.43122801068},"testStepId":"3"},"sequenceNumber":860,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #84: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":861,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 12 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19904060},"testStepId":"3"},"sequenceNumber":862,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 12 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":9719000},"testStepId":"3"},"sequenceNumber":863,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 12 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":488292.33834705083},"testStepId":"3"},"sequenceNumber":864,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #13: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":865,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 69 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19993874},"testStepId":"3"},"sequenceNumber":866,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 69 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16962000},"testStepId":"3"},"sequenceNumber":867,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 69 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":848359.85262285837},"testStepId":"3"},"sequenceNumber":868,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #70: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":869,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 49 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19965909},"testStepId":"3"},"sequenceNumber":870,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 49 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":16155000},"testStepId":"3"},"sequenceNumber":871,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 49 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":809129.2011798711},"testStepId":"3"},"sequenceNumber":872,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #50: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":873,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 60 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19903759},"testStepId":"3"},"sequenceNumber":874,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 60 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":18290000},"testStepId":"3"},"sequenceNumber":875,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 60 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":918921.89811984764},"testStepId":"3"},"sequenceNumber":876,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #61: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":877,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 113 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19982616},"testStepId":"3"},"sequenceNumber":878,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 113 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":17365000},"testStepId":"3"},"sequenceNumber":879,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 113 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":869005.33944104216},"testStepId":"3"},"sequenceNumber":880,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #114: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":881,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 84 Runtime","unit":"us","hardwareInfoId":"","validators":[],"metadata":{},"value":19915649},"testStepId":"3"},"sequenceNumber":882,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 84 Total Increments","unit":"increments","hardwareInfoId":"","validators":[],"metadata":{},"value":15689000},"testStepId":"3"},"sequenceNumber":883,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"measurement":{"name":"Cache Coherency Thread 84 Increment Rate","unit":"increment / second","hardwareInfoId":"","validators":[],"metadata":{},"value":787772.4697799203},"testStepId":"3"},"sequenceNumber":884,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"CPU Cache Coherency Thread #85: Finished CPU Cache Coherency thread"},"testStepId":"3"},"sequenceNumber":885,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"testStepStart":{"name":"Run Post-Test Memory Check Threads"},"testStepId":"4"},"sequenceNumber":886,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Finished countdown, beginning to check results"},"testStepId":"4"},"sequenceNumber":887,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 129"},"testStepId":"4"},"sequenceNumber":888,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 130"},"testStepId":"4"},"sequenceNumber":889,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #129: Starting Check thread"},"testStepId":"4"},"sequenceNumber":890,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 131"},"testStepId":"4"},"sequenceNumber":891,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #130: Starting Check thread"},"testStepId":"4"},"sequenceNumber":892,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 132"},"testStepId":"4"},"sequenceNumber":893,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #131: Starting Check thread"},"testStepId":"4"},"sequenceNumber":894,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 133"},"testStepId":"4"},"sequenceNumber":895,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #132: Starting Check thread"},"testStepId":"4"},"sequenceNumber":896,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 134"},"testStepId":"4"},"sequenceNumber":897,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #133: Starting Check thread"},"testStepId":"4"},"sequenceNumber":898,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #134: Starting Check thread"},"testStepId":"4"},"sequenceNumber":899,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 135"},"testStepId":"4"},"sequenceNumber":900,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Spawning check thread 136"},"testStepId":"4"},"sequenceNumber":901,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #135: Starting Check thread"},"testStepId":"4"},"sequenceNumber":902,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 129"},"testStepId":"4"},"sequenceNumber":903,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #136: Starting Check thread"},"testStepId":"4"},"sequenceNumber":904,"timestamp":"2023-05-01T20:45:49Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #134: Check thread completed with status 1, 36981 pages copied"},"testStepId":"4"},"sequenceNumber":905,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #133: Check thread completed with status 1, 35748 pages copied"},"testStepId":"4"},"sequenceNumber":906,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #135: Check thread completed with status 1, 37245 pages copied"},"testStepId":"4"},"sequenceNumber":907,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #132: Check thread completed with status 1, 37049 pages copied"},"testStepId":"4"},"sequenceNumber":908,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #136: Check thread completed with status 1, 35692 pages copied"},"testStepId":"4"},"sequenceNumber":909,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #130: Check thread completed with status 1, 36130 pages copied"},"testStepId":"4"},"sequenceNumber":910,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #131: Check thread completed with status 1, 37739 pages copied"},"testStepId":"4"},"sequenceNumber":911,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Memory Page Check Thread #129: Check thread completed with status 1, 37392 pages copied"},"testStepId":"4"},"sequenceNumber":912,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 130"},"testStepId":"4"},"sequenceNumber":913,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 131"},"testStepId":"4"},"sequenceNumber":914,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 132"},"testStepId":"4"},"sequenceNumber":915,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 133"},"testStepId":"4"},"sequenceNumber":916,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 134"},"testStepId":"4"},"sequenceNumber":917,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 135"},"testStepId":"4"},"sequenceNumber":918,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Joining check thread 136"},"testStepId":"4"},"sequenceNumber":919,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 129"},"testStepId":"4"},"sequenceNumber":920,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 129 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":921,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 130"},"testStepId":"4"},"sequenceNumber":922,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 130 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":923,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 131"},"testStepId":"4"},"sequenceNumber":924,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 131 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":925,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 132"},"testStepId":"4"},"sequenceNumber":926,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 132 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":927,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 133"},"testStepId":"4"},"sequenceNumber":928,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 133 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":929,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 134"},"testStepId":"4"},"sequenceNumber":930,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 134 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":931,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 135"},"testStepId":"4"},"sequenceNumber":932,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 135 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":933,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Reaping thread 136"},"testStepId":"4"},"sequenceNumber":934,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"log":{"severity":"DEBUG","message":"Thread 136 found 0 hardware incidents"},"testStepId":"4"},"sequenceNumber":935,"timestamp":"2023-05-01T20:45:53Z"}
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"4"},"sequenceNumber":936,"timestamp":"2023-05-01T20:45:53Z"}
2023/05/01-20:45:53(UTC) Stats: Found 0 hardware incidents
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"2"},"sequenceNumber":937,"timestamp":"2023-05-01T20:45:53Z"}
2023/05/01-20:45:53(UTC) Stats: Completed: 193540.00M in 20.06s 9645.68MB/s, with 0 hardware incidents, 0 errors
2023/05/01-20:45:53(UTC) Stats: Memory Copy: 193540.00M at 9670.87MB/s
2023/05/01-20:45:53(UTC) Stats: File Copy: 0.00M at 0.00MB/s
2023/05/01-20:45:53(UTC) Stats: Net Copy: 0.00M at 0.00MB/s
2023/05/01-20:45:53(UTC) Stats: Data Check: 0.00M at 0.00MB/s
2023/05/01-20:45:53(UTC) Stats: Invert Data: 0.00M at 0.00MB/s
2023/05/01-20:45:53(UTC) Stats: Disk: 0.00M at 0.00MB/s
{"testStepArtifact":{"testStepEnd":{"status":"COMPLETE"},"testStepId":"3"},"sequenceNumber":938,"timestamp":"2023-05-01T20:45:53Z"}
2023/05/01-20:45:53(UTC)
2023/05/01-20:45:53(UTC) Status: PASS - please verify no corrected errors
2023/05/01-20:45:53(UTC)
{"testRunArtifact":{"testRunEnd":{"status":"COMPLETE","result":"PASS"}},"sequenceNumber":939,"timestamp":"2023-05-01T20:45:55Z"}
```